### PR TITLE
Report page generation mismatch as page-not-found.

### DIFF
--- a/src/llfs/packed_page_header.hpp
+++ b/src/llfs/packed_page_header.hpp
@@ -13,7 +13,9 @@
 #include <llfs/int_types.hpp>
 #include <llfs/packed_page_id.hpp>
 #include <llfs/packed_page_user_slot.hpp>
+#include <llfs/page_id_factory.hpp>
 #include <llfs/page_layout_id.hpp>
+#include <llfs/page_size.hpp>
 
 #include <batteries/assert.hpp>
 
@@ -42,7 +44,8 @@ struct PackedPageHeader {
     return this->size - this->unused_size();
   }
 
-  Status sanity_check(usize page_size, PageId page_id) const noexcept;
+  Status sanity_check(PageSize page_size, PageId page_id,
+                      const PageIdFactory& id_factory) const noexcept;
 
   big_u64 magic;
   PackedPageId page_id;

--- a/src/llfs/page_recycler.cpp
+++ b/src/llfs/page_recycler.cpp
@@ -514,7 +514,9 @@ void PageRecycler::recycle_task_main()
       // We must write a PackedRecyclePagePrepare event to the WAL in case we need to recover from
       // a crash.
       //
-      BATT_ASSIGN_OK_RESULT(this->prepared_batch_, this->prepare_batch(std::move(to_recycle)));
+      StatusOr<PageRecycler::Batch> next_batch = this->prepare_batch(std::move(to_recycle));
+      BATT_REQUIRE_OK(next_batch);
+      this->prepared_batch_ = std::move(*next_batch);
     }
   }();
 

--- a/src/llfs/status_code.cpp
+++ b/src/llfs/status_code.cpp
@@ -111,6 +111,7 @@ bool initialize_status_codes()
       CODE_WITH_MSG_(StatusCode::kPageHeaderBadUnusedSize, "Sanity check failed"),            // 50,
       CODE_WITH_MSG_(StatusCode::kPageHeaderBadUnusedBegin, "Sanity check failed"),           // 51,
       CODE_WITH_MSG_(StatusCode::kPageHeaderBadUnusedEnd, "Sanity check failed"),             // 52,
+      CODE_WITH_MSG_(StatusCode::kPageHeaderBadGeneration, "Sanity check failed"),            // 53,
   });
   return initialized;
 }

--- a/src/llfs/status_code.hpp
+++ b/src/llfs/status_code.hpp
@@ -68,6 +68,7 @@ enum struct StatusCode {
   kPageHeaderBadUnusedSize = 50,
   kPageHeaderBadUnusedBegin = 51,
   kPageHeaderBadUnusedEnd = 52,
+  kPageHeaderBadGeneration = 53,
 };
 
 bool initialize_status_codes();

--- a/src/llfs/volume_trimmer.cpp
+++ b/src/llfs/volume_trimmer.cpp
@@ -560,7 +560,7 @@ Status trim_volume_log(TypedSlotWriter<VolumeEventVariant>& slot_writer, batt::G
     std::swap(reserve_size, trimmed_region.grant_size_to_reserve);
     StatusOr<batt::Grant> reserved =
         trimmed_space->spend(reserve_size, batt::WaitForResource::kFalse);
-    BATT_CHECK_OK(reserved) << BATT_INSPECT(reserve_size) << BATT_INSPECT(trimmed_space->size());
+    BATT_REQUIRE_OK(reserved) << BATT_INSPECT(reserve_size) << BATT_INSPECT(trimmed_space->size());
 
     grant.subsume(std::move(*reserved));
   }
@@ -569,7 +569,7 @@ Status trim_volume_log(TypedSlotWriter<VolumeEventVariant>& slot_writer, batt::G
     usize release_size = 0;
     std::swap(release_size, trimmed_region.grant_size_to_release);
     StatusOr<batt::Grant> released = grant.spend(release_size, batt::WaitForResource::kFalse);
-    BATT_CHECK_OK(released);
+    BATT_REQUIRE_OK(released);
   }
 
   // Move pending jobs from the trimmed region to `prior_pending_jobs`


### PR DESCRIPTION
This fixes a regression in PageRecycler where deleting a page twice fails because the page is reallocated, resulting in a page id (generation) mismatch.