### PR TITLE
Fix CI pipeline and changed ScopedIoRing API.

### DIFF
--- a/src/llfs/ioring_file.cpp
+++ b/src/llfs/ioring_file.cpp
@@ -19,13 +19,13 @@ namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-IoRing::File::File(IoRing& io, int fd) noexcept : io_{&io}, fd_{fd}
+IoRing::File::File(const IoRing& io_ring, int fd) noexcept : io_ring_{&io_ring}, fd_{fd}
 {
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-IoRing::File::File(File&& that) noexcept : io_{that.io_}, fd_{that.fd_}
+IoRing::File::File(File&& that) noexcept : io_ring_{that.io_ring_}, fd_{that.fd_}
 {
   that.fd_ = -1;
   that.registered_fd_ = -1;
@@ -37,7 +37,7 @@ auto IoRing::File::operator=(File&& that) noexcept -> File&
 {
   File copy{std::move(that)};
 
-  std::swap(this->io_, copy.io_);
+  std::swap(this->io_ring_, copy.io_ring_);
   std::swap(this->fd_, copy.fd_);
   std::swap(this->registered_fd_, copy.registered_fd_);
 
@@ -133,7 +133,7 @@ Status IoRing::File::register_fd()
     return OkStatus();
   }
 
-  StatusOr<i32> rfd = this->io_->register_fd(this->fd_);
+  StatusOr<i32> rfd = this->io_ring_->register_fd(this->fd_);
   if (!rfd.ok()) {
     LLFS_LOG_ERROR() << "register_fd failed! " << BATT_INSPECT(rfd.status());
   }
@@ -152,7 +152,7 @@ Status IoRing::File::unregister_fd()
     return OkStatus();
   }
 
-  Status status = this->io_->unregister_fd(this->registered_fd_);
+  Status status = this->io_ring_->unregister_fd(this->registered_fd_);
   BATT_REQUIRE_OK(status);
 
   this->registered_fd_ = -1;

--- a/src/llfs/ioring_file.hpp
+++ b/src/llfs/ioring_file.hpp
@@ -29,7 +29,7 @@ class IoRing::File
   //
   static constexpr i32 kBlockAlignmentLog2 = 12;
 
-  explicit File(IoRing& io, int fd) noexcept;
+  explicit File(const IoRing& io_ring, int fd) noexcept;
 
   File(const File&) = delete;
   File& operator=(const File&) = delete;
@@ -39,9 +39,9 @@ class IoRing::File
 
   ~File() noexcept;
 
-  IoRing& get_io_ring() const
+  const IoRing& get_io_ring() const
   {
-    return *this->io_;
+    return *this->io_ring_;
   }
 
   // Asynchronously reads data from the file starting at the given offset, copying read data into
@@ -125,7 +125,7 @@ class IoRing::File
   int get_fd() const;
 
  private:
-  IoRing* io_;
+  const IoRing* io_ring_;
   int fd_ = -1;
   int registered_fd_ = -1;
 };
@@ -139,16 +139,16 @@ inline void IoRing::File::async_read_some(i64 offset, MutableBufferSequence&& bu
                                           Handler&& handler)
 {
   LLFS_DVLOG(1) << "async_read_some(mulitple buffers)";
-  this->io_->submit(BATT_FORWARD(buffers), BATT_FORWARD(handler),
-                    [offset, this](struct io_uring_sqe* sqe, auto& op) {
-                      if (this->registered_fd_ == -1) {
-                        io_uring_prep_readv(sqe, this->fd_, op.iov_, op.iov_count_, offset);
-                      } else {
-                        io_uring_prep_readv(sqe, this->registered_fd_, op.iov_, op.iov_count_,
-                                            offset);
-                        sqe->flags |= IOSQE_FIXED_FILE;
-                      }
-                    });
+  this->io_ring_->submit(BATT_FORWARD(buffers), BATT_FORWARD(handler),
+                         [offset, this](struct io_uring_sqe* sqe, auto& op) {
+                           if (this->registered_fd_ == -1) {
+                             io_uring_prep_readv(sqe, this->fd_, op.iov_, op.iov_count_, offset);
+                           } else {
+                             io_uring_prep_readv(sqe, this->registered_fd_, op.iov_, op.iov_count_,
+                                                 offset);
+                             sqe->flags |= IOSQE_FIXED_FILE;
+                           }
+                         });
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -160,7 +160,7 @@ inline void IoRing::File::async_read_some(i64 offset, const MutableBuffer& buffe
   static const std::vector<MutableBuffer> empty;
 
   LLFS_DVLOG(1) << "async_read_some(single buffer)";
-  this->io_->submit(
+  this->io_ring_->submit(
       empty, BATT_FORWARD(handler),
       [&buffer, offset, this](struct io_uring_sqe* sqe, auto& /*op*/) {
         if (this->registered_fd_ == -1) {
@@ -180,16 +180,16 @@ template <typename ConstBufferSequence, typename Handler, typename>
 inline void IoRing::File::async_write_some(i64 offset, ConstBufferSequence&& buffers,
                                            Handler&& handler)
 {
-  this->io_->submit(BATT_FORWARD(buffers), BATT_FORWARD(handler),
-                    [offset, this](struct io_uring_sqe* sqe, auto& op) {
-                      if (this->registered_fd_ == -1) {
-                        io_uring_prep_writev(sqe, this->fd_, op.iov_, op.iov_count_, offset);
-                      } else {
-                        io_uring_prep_writev(sqe, this->registered_fd_, op.iov_, op.iov_count_,
-                                             offset);
-                        sqe->flags |= IOSQE_FIXED_FILE;
-                      }
-                    });
+  this->io_ring_->submit(BATT_FORWARD(buffers), BATT_FORWARD(handler),
+                         [offset, this](struct io_uring_sqe* sqe, auto& op) {
+                           if (this->registered_fd_ == -1) {
+                             io_uring_prep_writev(sqe, this->fd_, op.iov_, op.iov_count_, offset);
+                           } else {
+                             io_uring_prep_writev(sqe, this->registered_fd_, op.iov_, op.iov_count_,
+                                                  offset);
+                             sqe->flags |= IOSQE_FIXED_FILE;
+                           }
+                         });
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -199,16 +199,16 @@ inline void IoRing::File::async_write_some(i64 offset, const ConstBuffer& buffer
 {
   static const std::vector<ConstBuffer> empty;
 
-  this->io_->submit(empty, BATT_FORWARD(handler),
-                    [&buffer, offset, this](struct io_uring_sqe* sqe, auto& /*op*/) {
-                      if (this->registered_fd_ == -1) {
-                        io_uring_prep_write(sqe, this->fd_, buffer.data(), buffer.size(), offset);
-                      } else {
-                        io_uring_prep_write(sqe, this->registered_fd_, buffer.data(), buffer.size(),
-                                            offset);
-                        sqe->flags |= IOSQE_FIXED_FILE;
-                      }
-                    });
+  this->io_ring_->submit(
+      empty, BATT_FORWARD(handler),
+      [&buffer, offset, this](struct io_uring_sqe* sqe, auto& /*op*/) {
+        if (this->registered_fd_ == -1) {
+          io_uring_prep_write(sqe, this->fd_, buffer.data(), buffer.size(), offset);
+        } else {
+          io_uring_prep_write(sqe, this->registered_fd_, buffer.data(), buffer.size(), offset);
+          sqe->flags |= IOSQE_FIXED_FILE;
+        }
+      });
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -219,17 +219,18 @@ inline void IoRing::File::async_write_some_fixed(i64 offset, const ConstBuffer& 
 {
   static const std::vector<ConstBuffer> empty;
 
-  this->io_->submit(empty, BATT_FORWARD(handler),
-                    [&buffer, buf_index, offset, this](struct io_uring_sqe* sqe, auto& /*op*/) {
-                      if (this->registered_fd_ == -1) {
-                        io_uring_prep_write_fixed(sqe, this->fd_, buffer.data(), buffer.size(),
-                                                  offset, buf_index);
-                      } else {
-                        io_uring_prep_write_fixed(sqe, this->registered_fd_, buffer.data(),
-                                                  buffer.size(), offset, buf_index);
-                        sqe->flags |= IOSQE_FIXED_FILE;
-                      }
-                    });
+  this->io_ring_->submit(
+      empty, BATT_FORWARD(handler),
+      [&buffer, buf_index, offset, this](struct io_uring_sqe* sqe, auto& /*op*/) {
+        if (this->registered_fd_ == -1) {
+          io_uring_prep_write_fixed(sqe, this->fd_, buffer.data(), buffer.size(), offset,
+                                    buf_index);
+        } else {
+          io_uring_prep_write_fixed(sqe, this->registered_fd_, buffer.data(), buffer.size(), offset,
+                                    buf_index);
+          sqe->flags |= IOSQE_FIXED_FILE;
+        }
+      });
 }
 
 }  // namespace llfs

--- a/src/llfs/ioring_file_runtime_options.cpp
+++ b/src/llfs/ioring_file_runtime_options.cpp
@@ -17,10 +17,11 @@ namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-/*static*/ IoRingFileRuntimeOptions IoRingFileRuntimeOptions::with_default_values(IoRing& io)
+/*static*/ IoRingFileRuntimeOptions IoRingFileRuntimeOptions::with_default_values(
+    const IoRing& io_ring)
 {
   return IoRingFileRuntimeOptions{
-      .io = io,
+      .io_ring = io_ring,
       .use_raw_io = true,
       .allow_read = true,
       .allow_write = true,
@@ -57,7 +58,7 @@ StatusOr<IoRing::File> open_ioring_file(const std::string& file_name,
   });
   BATT_REQUIRE_OK(batt::status_from_retval(fd));
 
-  return IoRing::File{file_options.io, fd};
+  return IoRing::File{file_options.io_ring, fd};
 }
 
 }  // namespace llfs

--- a/src/llfs/ioring_file_runtime_options.hpp
+++ b/src/llfs/ioring_file_runtime_options.hpp
@@ -19,9 +19,9 @@
 namespace llfs {
 
 struct IoRingFileRuntimeOptions {
-  static IoRingFileRuntimeOptions with_default_values(IoRing& io);
+  static IoRingFileRuntimeOptions with_default_values(const IoRing& io_ring);
 
-  IoRing& io;
+  const IoRing& io_ring;
   bool use_raw_io;
   bool allow_read;
   bool allow_write;

--- a/src/llfs/ioring_log_device.test.cpp
+++ b/src/llfs/ioring_log_device.test.cpp
@@ -51,7 +51,7 @@ TEST(IoringLogDeviceTest, StorageFile)
     ASSERT_TRUE(scoped_ioring.ok()) << BATT_INSPECT(scoped_ioring.status());
 
     auto storage_context = batt::make_shared<llfs::StorageContext>(
-        batt::Runtime::instance().default_scheduler(), scoped_ioring->get());
+        batt::Runtime::instance().default_scheduler(), scoped_ioring->get_io_ring());
 
     // Remove the file if it already exists.
     //

--- a/src/llfs/raw_block_file_impl.cpp
+++ b/src/llfs/raw_block_file_impl.cpp
@@ -27,7 +27,7 @@ namespace llfs {
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 /*static*/ StatusOr<std::unique_ptr<IoRingRawBlockFile>> IoRingRawBlockFile::open(
-    IoRing& io, const char* file_name, int flags, Optional<mode_t> mode)
+    const IoRing& io_ring, const char* file_name, int flags, Optional<mode_t> mode)
 {
   const int fd = batt::syscall_retry([&] {
     if (mode) {
@@ -38,7 +38,7 @@ namespace llfs {
   });
   BATT_REQUIRE_OK(batt::status_from_retval(fd));
 
-  return std::make_unique<IoRingRawBlockFile>(IoRing::File{io, fd});
+  return std::make_unique<IoRingRawBlockFile>(IoRing::File{io_ring, fd});
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/raw_block_file_impl.hpp
+++ b/src/llfs/raw_block_file_impl.hpp
@@ -25,8 +25,9 @@ namespace llfs {
 class IoRingRawBlockFile : public RawBlockFile
 {
  public:
-  static StatusOr<std::unique_ptr<IoRingRawBlockFile>> open(IoRing& io, const char* file_name,
-                                                            int flags, Optional<mode_t> mode);
+  static StatusOr<std::unique_ptr<IoRingRawBlockFile>> open(const IoRing& io_ring,
+                                                            const char* file_name, int flags,
+                                                            Optional<mode_t> mode);
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/llfs/storage_context.hpp
+++ b/src/llfs/storage_context.hpp
@@ -41,7 +41,7 @@ class StorageContext : public batt::RefCounted<StorageContext>
   // Construct a new StorageContext that will use the given TaskScheduler and IoRing for background
   // tasks and asynchronous file I/O.
   //
-  explicit StorageContext(batt::TaskScheduler& scheduler, IoRing& io) noexcept;
+  explicit StorageContext(batt::TaskScheduler& scheduler, const IoRing& io) noexcept;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
   // noncopyable
@@ -55,9 +55,9 @@ class StorageContext : public batt::RefCounted<StorageContext>
     return this->scheduler_;
   }
 
-  IoRing& get_ioring() const
+  const IoRing& get_io_ring() const
   {
-    return this->io_;
+    return *this->io_ring_;
   }
 
   /*! \brief Set runtime options for PageCache.
@@ -134,7 +134,7 @@ class StorageContext : public batt::RefCounted<StorageContext>
 
   // Passed in at creation time; this is the default IoRing used to perform I/O.
   //
-  IoRing& io_;
+  const IoRing* io_ring_;
 
   // An index of all storage objects by uuid.
   //

--- a/src/llfs/storage_context.test.cpp
+++ b/src/llfs/storage_context.test.cpp
@@ -44,7 +44,7 @@ TEST(StorageContextTest, GetPageCache)
   // Create a StorageContext.
   //
   batt::SharedPtr<llfs::StorageContext> storage_context = batt::make_shared<llfs::StorageContext>(
-      batt::Runtime::instance().default_scheduler(), io->get());
+      batt::Runtime::instance().default_scheduler(), io->get_io_ring());
 
   boost::uuids::uuid arena_uuid_4kb = llfs::random_uuid();
   boost::uuids::uuid arena_uuid_2mb = llfs::random_uuid();

--- a/src/llfs/storage_file_builder.test.cpp
+++ b/src/llfs/storage_file_builder.test.cpp
@@ -166,7 +166,7 @@ TEST_F(StorageFileBuilderTest, WriteReadFile)
   ASSERT_TRUE(ioring.ok()) << BATT_INSPECT(ioring.status());
 
   auto storage_context = batt::make_shared<llfs::StorageContext>(
-      batt::Runtime::instance().default_scheduler(), ioring->get());
+      batt::Runtime::instance().default_scheduler(), ioring->get_io_ring());
 
   const char* const test_file_name = "/tmp/llfs_test_file";
   std::filesystem::remove(test_file_name);
@@ -180,7 +180,7 @@ TEST_F(StorageFileBuilderTest, WriteReadFile)
       llfs::Status status = llfs::enable_raw_io_fd(*test_fd, /*enabled=*/true);
       ASSERT_TRUE(status.ok()) << BATT_INSPECT(status);
     }
-    llfs::IoRingRawBlockFile test_file{llfs::IoRing::File{ioring->get(), *test_fd}};
+    llfs::IoRingRawBlockFile test_file{llfs::IoRing::File{ioring->get_io_ring(), *test_fd}};
 
     const auto page_device_options = llfs::PageDeviceConfigOptions{
         .uuid = llfs::None,
@@ -236,7 +236,7 @@ TEST_F(StorageFileBuilderTest, WriteReadFile)
   llfs::StatusOr<std::unique_ptr<llfs::PageDevice>> recovered_device =
       storage_context->recover_object(
           batt::StaticType<llfs::PackedPageDeviceConfig>{}, page_device_uuid,
-          llfs::IoRingFileRuntimeOptions::with_default_values(ioring->get()));
+          llfs::IoRingFileRuntimeOptions::with_default_values(ioring->get_io_ring()));
 
   ASSERT_TRUE(recovered_device.ok()) << BATT_INSPECT(recovered_device.status());
 }

--- a/src/llfs/volume_config.test.cpp
+++ b/src/llfs/volume_config.test.cpp
@@ -75,7 +75,7 @@ class VolumeConfigTest : public ::testing::Test
   void create_storage_context()
   {
     this->storage_context_ = batt::make_shared<llfs::StorageContext>(
-        batt::Runtime::instance().default_scheduler(), this->ioring_.get());
+        batt::Runtime::instance().default_scheduler(), this->ioring_.get_io_ring());
   }
 
   // Returns default VolumeRuntimeOptions for tests.

--- a/src/llfs_cli/list_command.cpp
+++ b/src/llfs_cli/list_command.cpp
@@ -50,8 +50,8 @@ void run_list_command(ListCommandArgs& args)
   for (auto f : args.files) {
     std::cout << f << ":" << std::endl;
 
-    StatusOr<std::unique_ptr<IoRingRawBlockFile>> file =
-        IoRingRawBlockFile::open(ioring->get(), f.c_str(), /*flags=*/O_RDONLY, /*mode=*/None);
+    StatusOr<std::unique_ptr<IoRingRawBlockFile>> file = IoRingRawBlockFile::open(
+        ioring->get_io_ring(), f.c_str(), /*flags=*/O_RDONLY, /*mode=*/None);
     BATT_CHECK_OK(file);
 
     StatusOr<std::vector<std::unique_ptr<StorageFileConfigBlock>>> config_blocks =


### PR DESCRIPTION
There was a recent downstream bug whose root cause was a `std::move` of the IoRing object out of a ScopedIoRing.  The intention had been to move the ScopedIoRing itself.  This broke the `ScopedIoRing::Impl` since it assumes it has sole ownership over the contained IoRing.  The fix is:

- Rename `ScopedIoRing::get` to `get_io_ring` so it won't be confused with `unique_ptr::get` or `StatusOr::get`
- Return a `const&` instead of `&` from this method, to prevent further move-copying
- Declare most methods of IoRing as const to fix downstream breakage (since IoRing uses the pointer-to-impl pattern, and const often just means "thread-safe", I think this change works in practical terms and maintains the spirit of the modern C++ design)