### PR TITLE
Address #40.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_compile_options(-D_GNU_SOURCE -fno-omit-frame-pointer)
 # Set warning/error level for the compilation.
 #
 add_compile_options(-Wall -Wextra -Werror -Werror=switch-enum -Wswitch-enum)
+add_compile_options(-Wsuggest-override -Woverloaded-virtual)
 
 # Configuration macros for Boost.
 #

--- a/src/llfs/basic_ring_buffer_log_device.hpp
+++ b/src/llfs/basic_ring_buffer_log_device.hpp
@@ -209,18 +209,18 @@ class BasicRingBufferLogDevice<Impl>::WriterImpl : public LogDevice::Writer
     return this->device_->driver_.get_commit_pos();
   }
 
-  std::size_t space() const
+  u64 space() const override
   {
     const slot_offset_type readable_begin = this->device_->driver_.get_trim_pos();
     const slot_offset_type readable_end = this->device_->driver_.get_commit_pos();
 
-    const std::size_t space_available =
+    const usize space_available =
         this->device_->buffer_.size() - slot_distance(readable_begin, readable_end);
 
     return space_available;
   }
 
-  StatusOr<MutableBuffer> prepare(std::size_t byte_count, std::size_t head_room) override
+  StatusOr<MutableBuffer> prepare(usize byte_count, usize head_room) override
   {
     BATT_CHECK(!this->prepared_offset_);
 
@@ -228,7 +228,7 @@ class BasicRingBufferLogDevice<Impl>::WriterImpl : public LogDevice::Writer
       return ::llfs::make_status(StatusCode::kPrepareFailedLogClosed);
     }
 
-    const std::size_t space_required = byte_count + head_room;
+    const usize space_required = byte_count + head_room;
 
     if (this->space() < space_required) {
       return ::llfs::make_status(StatusCode::kPrepareFailedTrimRequired);
@@ -242,7 +242,7 @@ class BasicRingBufferLogDevice<Impl>::WriterImpl : public LogDevice::Writer
     return MutableBuffer{writable_region.data(), byte_count};
   }
 
-  StatusOr<slot_offset_type> commit(std::size_t byte_count) override
+  StatusOr<slot_offset_type> commit(usize byte_count) override
   {
     auto guard = batt::finally([&] {
       this->prepared_offset_ = None;

--- a/src/llfs/finalized_page_cache_job.cpp
+++ b/src/llfs/finalized_page_cache_job.cpp
@@ -98,10 +98,9 @@ void FinalizedPageCacheJob::prefetch_hint(PageId page_id) /*override*/
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> FinalizedPageCacheJob::get(PageId page_id,
-                                                const Optional<PageLayoutId>& required_layout,
-                                                PinPageToJob pin_page_to_job,
-                                                OkIfNotFound ok_if_not_found) /*override*/
+StatusOr<PinnedPage> FinalizedPageCacheJob::get_page_with_layout_in_job(
+    PageId page_id, const Optional<PageLayoutId>& required_layout, PinPageToJob pin_page_to_job,
+    OkIfNotFound ok_if_not_found) /*override*/
 {
   if (bool_from(pin_page_to_job, /*default_value=*/false)) {
     return Status{batt::StatusCode::kUnimplemented};

--- a/src/llfs/finalized_page_cache_job.hpp
+++ b/src/llfs/finalized_page_cache_job.hpp
@@ -114,8 +114,10 @@ class FinalizedPageCacheJob : public PageLoader
 
   void prefetch_hint(PageId page_id) override;
 
-  StatusOr<PinnedPage> get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                           PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found) override;
+  StatusOr<PinnedPage> get_page_with_layout_in_job(PageId page_id,
+                                                   const Optional<PageLayoutId>& required_layout,
+                                                   PinPageToJob pin_page_to_job,
+                                                   OkIfNotFound ok_if_not_found) override;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/llfs/page_cache.cpp
+++ b/src/llfs/page_cache.cpp
@@ -438,8 +438,9 @@ void PageCache::purge(PageId page_id, u64 callers, u64 job_id)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageCache::get(PageId page_id, const Optional<PageLayoutId>& require_layout,
-                                    PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageCache::get_page_with_layout_in_job(
+    PageId page_id, const Optional<PageLayoutId>& require_layout, PinPageToJob pin_page_to_job,
+    OkIfNotFound ok_if_not_found)
 {
   if (bool_from(pin_page_to_job, /*default_value=*/false)) {
     return Status{batt::StatusCode::kUnimplemented};

--- a/src/llfs/page_cache.hpp
+++ b/src/llfs/page_cache.hpp
@@ -165,7 +165,13 @@ class PageCache : public PageLoader
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   // PageLoader interface
   //
-  using PageLoader::get;
+  using PageLoader::get_page;
+  using PageLoader::get_page_in_job;
+  using PageLoader::get_page_slot;
+  using PageLoader::get_page_slot_in_job;
+  using PageLoader::get_page_slot_with_layout;
+  using PageLoader::get_page_slot_with_layout_in_job;
+  using PageLoader::get_page_with_layout;
 
   // Gives a hint to the cache to fetch the pages for the given ids in the background because we are
   // going to need them soon.
@@ -174,8 +180,10 @@ class PageCache : public PageLoader
 
   // Loads the specified page or retrieves from cache.
   //
-  StatusOr<PinnedPage> get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                           PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found) override;
+  StatusOr<PinnedPage> get_page_with_layout_in_job(PageId page_id,
+                                                   const Optional<PageLayoutId>& required_layout,
+                                                   PinPageToJob pin_page_to_job,
+                                                   OkIfNotFound ok_if_not_found) override;
   //
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/llfs/page_cache_job.cpp
+++ b/src/llfs/page_cache_job.cpp
@@ -223,9 +223,9 @@ void PageCacheJob::unpin_all()
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageCacheJob::get(PageId page_id,
-                                       const Optional<PageLayoutId>& required_layout,
-                                       PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageCacheJob::get_page_with_layout_in_job(
+    PageId page_id, const Optional<PageLayoutId>& required_layout, PinPageToJob pin_page_to_job,
+    OkIfNotFound ok_if_not_found)
 {
   // First check in the pinned pages table.
   {
@@ -297,7 +297,7 @@ StatusOr<PinnedPage> PageCacheJob::const_get(PageId page_id,
   if (pinned_page.status() != batt::StatusCode::kUnavailable) {
     return pinned_page;
   }
-  return this->cache_->get(page_id, required_layout, ok_if_not_found);
+  return this->cache_->get_page_with_layout(page_id, required_layout, ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -323,8 +323,8 @@ void PageCacheJob::const_prefetch_hint(PageId page_id) const
 Status PageCacheJob::recover_page(PageId page_id, const boost::uuids::uuid& caller_uuid,
                                   slot_offset_type caller_slot)
 {
-  StatusOr<PinnedPage> pinned_page =
-      this->get(page_id, /*required_layout=*/None, PinPageToJob::kTrue, OkIfNotFound{false});
+  StatusOr<PinnedPage> pinned_page = this->get_page_with_layout_in_job(
+      page_id, /*required_layout=*/None, PinPageToJob::kTrue, OkIfNotFound{false});
 
   BATT_REQUIRE_OK(pinned_page);
 
@@ -351,7 +351,7 @@ Status PageCacheJob::delete_page(PageId page_id)
   if (!page_id) {
     return OkStatus();
   }
-  StatusOr<PinnedPage> page_view = this->get(page_id, OkIfNotFound{true});
+  StatusOr<PinnedPage> page_view = this->get_page(page_id, OkIfNotFound{true});
   if (page_view.ok()) {
     this->pruned_ = false;
     this->deleted_pages_.emplace(page_id, *page_view);

--- a/src/llfs/page_cache_job.hpp
+++ b/src/llfs/page_cache_job.hpp
@@ -173,7 +173,13 @@ class PageCacheJob : public PageLoader
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   // PageLoader interface
   //
-  using PageLoader::get;
+  using PageLoader::get_page;
+  using PageLoader::get_page_in_job;
+  using PageLoader::get_page_slot;
+  using PageLoader::get_page_slot_in_job;
+  using PageLoader::get_page_slot_with_layout;
+  using PageLoader::get_page_slot_with_layout_in_job;
+  using PageLoader::get_page_with_layout;
 
   // Hint to the cache that it is likely we will ask for this page in the near future.
   //
@@ -181,8 +187,10 @@ class PageCacheJob : public PageLoader
 
   // Load the page, first checking the pinned pages and views in this job.
   //
-  StatusOr<PinnedPage> get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                           PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found) override;
+  StatusOr<PinnedPage> get_page_with_layout_in_job(PageId page_id,
+                                                   const Optional<PageLayoutId>& required_layout,
+                                                   PinPageToJob pin_page_to_job,
+                                                   OkIfNotFound ok_if_not_found) override;
   //
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -284,7 +292,7 @@ class PageCacheJob : public PageLoader
   }
 
   LLFS_METHOD_BINDER(PageCacheJob, prefetch_hint, Prefetch);
-  LLFS_METHOD_BINDER(PageCacheJob, get, Get);
+  LLFS_METHOD_BINDER(PageCacheJob, get_page_slot, Get);
 
   int binder_count = 0;
 

--- a/src/llfs/page_id_slot.cpp
+++ b/src/llfs/page_id_slot.cpp
@@ -38,8 +38,8 @@ batt::StatusOr<PinnedPage> PageIdSlot::load_through(PageLoader& loader,
       return pinned;
     }
   }
-  batt::StatusOr<PinnedPage> pinned =
-      loader.get(this->page_id, required_layout, pin_page_to_job, ok_if_not_found);
+  batt::StatusOr<PinnedPage> pinned = loader.get_page_with_layout_in_job(
+      this->page_id, required_layout, pin_page_to_job, ok_if_not_found);
   if (pinned.ok()) {
     this->cache_slot_ref = pinned->get_cache_slot();
   }

--- a/src/llfs/page_loader.cpp
+++ b/src/llfs/page_loader.cpp
@@ -38,58 +38,66 @@ bool bool_from(PinPageToJob pin_page, bool default_value)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(const PageIdSlot& page_id_slot,
-                                     const Optional<PageLayoutId>& required_layout,
-                                     PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page_slot_with_layout_in_job(
+    const PageIdSlot& page_id_slot, const Optional<PageLayoutId>& required_layout,
+    PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found)
 {
   return page_id_slot.load_through(*this, required_layout, pin_page_to_job, ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(const PageIdSlot& page_id_slot,
-                                     const Optional<PageLayoutId>& required_layout,
-                                     OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page_slot_with_layout(
+    const PageIdSlot& page_id_slot, const Optional<PageLayoutId>& required_layout,
+    OkIfNotFound ok_if_not_found)
 {
-  return this->get(page_id_slot, required_layout, PinPageToJob::kDefault, ok_if_not_found);
+  return this->get_page_slot_with_layout_in_job(page_id_slot, required_layout,
+                                                PinPageToJob::kDefault, ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(const PageIdSlot& page_id_slot, PinPageToJob pin_page_to_job,
-                                     OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page_slot_in_job(const PageIdSlot& page_id_slot,
+                                                      PinPageToJob pin_page_to_job,
+                                                      OkIfNotFound ok_if_not_found)
 {
-  return this->get(page_id_slot, /*required_layout=*/None, pin_page_to_job, ok_if_not_found);
+  return this->get_page_slot_with_layout_in_job(page_id_slot, /*required_layout=*/None,
+                                                pin_page_to_job, ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(const PageIdSlot& page_id_slot, OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page_slot(const PageIdSlot& page_id_slot,
+                                               OkIfNotFound ok_if_not_found)
 {
-  return this->get(page_id_slot, /*required_layout=*/None, PinPageToJob::kDefault, ok_if_not_found);
+  return this->get_page_slot_with_layout_in_job(page_id_slot, /*required_layout=*/None,
+                                                PinPageToJob::kDefault, ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                                     OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page_with_layout(PageId page_id,
+                                                      const Optional<PageLayoutId>& required_layout,
+                                                      OkIfNotFound ok_if_not_found)
 {
-  return this->get(page_id, required_layout, PinPageToJob::kDefault, ok_if_not_found);
+  return this->get_page_with_layout_in_job(page_id, required_layout, PinPageToJob::kDefault,
+                                           ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(PageId page_id, PinPageToJob pin_page_to_job,
-                                     OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page_in_job(PageId page_id, PinPageToJob pin_page_to_job,
+                                                 OkIfNotFound ok_if_not_found)
 {
-  return this->get(page_id, /*required_layout=*/None, pin_page_to_job, ok_if_not_found);
+  return this->get_page_with_layout_in_job(page_id, /*required_layout=*/None, pin_page_to_job,
+                                           ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> PageLoader::get(PageId page_id, OkIfNotFound ok_if_not_found)
+StatusOr<PinnedPage> PageLoader::get_page(PageId page_id, OkIfNotFound ok_if_not_found)
 {
-  return this->get(page_id, /*required_layout=*/None, ok_if_not_found);
+  return this->get_page_with_layout(page_id, /*required_layout=*/None, ok_if_not_found);
 }
 
 }  // namespace llfs

--- a/src/llfs/page_loader.hpp
+++ b/src/llfs/page_loader.hpp
@@ -34,31 +34,35 @@ class PageLoader
 
   virtual void prefetch_hint(PageId page_id) = 0;
 
-  virtual StatusOr<PinnedPage> get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                                   PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found) = 0;
+  virtual StatusOr<PinnedPage> get_page_with_layout_in_job(
+      PageId page_id, const Optional<PageLayoutId>& required_layout, PinPageToJob pin_page_to_job,
+      OkIfNotFound ok_if_not_found) = 0;
 
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
-  virtual StatusOr<PinnedPage> get(const PageIdSlot& page_id_slot,
-                                   const Optional<PageLayoutId>& required_layout,
-                                   PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page_slot_with_layout_in_job(
+      const PageIdSlot& page_id_slot, const Optional<PageLayoutId>& required_layout,
+      PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found);
 
-  virtual StatusOr<PinnedPage> get(const PageIdSlot& page_id_slot,
-                                   const Optional<PageLayoutId>& required_layout,
-                                   OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page_slot_with_layout(
+      const PageIdSlot& page_id_slot, const Optional<PageLayoutId>& required_layout,
+      OkIfNotFound ok_if_not_found);
 
-  virtual StatusOr<PinnedPage> get(const PageIdSlot& page_id_slot, PinPageToJob pin_page_to_job,
-                                   OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page_slot_in_job(const PageIdSlot& page_id_slot,
+                                                    PinPageToJob pin_page_to_job,
+                                                    OkIfNotFound ok_if_not_found);
 
-  virtual StatusOr<PinnedPage> get(const PageIdSlot& page_id_slot, OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page_slot(const PageIdSlot& page_id_slot,
+                                             OkIfNotFound ok_if_not_found);
 
-  virtual StatusOr<PinnedPage> get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                                   OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page_with_layout(PageId page_id,
+                                                    const Optional<PageLayoutId>& required_layout,
+                                                    OkIfNotFound ok_if_not_found);
 
-  virtual StatusOr<PinnedPage> get(PageId page_id, PinPageToJob pin_page_to_job,
-                                   OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page_in_job(PageId page_id, PinPageToJob pin_page_to_job,
+                                               OkIfNotFound ok_if_not_found);
 
-  virtual StatusOr<PinnedPage> get(PageId page_id, OkIfNotFound ok_if_not_found);
+  virtual StatusOr<PinnedPage> get_page(PageId page_id, OkIfNotFound ok_if_not_found);
 
  protected:
   PageLoader() = default;

--- a/src/llfs/trace_refs_recursive.hpp
+++ b/src/llfs/trace_refs_recursive.hpp
@@ -44,7 +44,7 @@ inline batt::Status trace_refs_recursive(PageLoader& page_loader, IdTypePairSeq&
     const PageId next = pending.back();
     pending.pop_back();
 
-    batt::StatusOr<PinnedPage> status_or_page = page_loader.get(next, OkIfNotFound{false});
+    batt::StatusOr<PinnedPage> status_or_page = page_loader.get_page(next, OkIfNotFound{false});
     BATT_REQUIRE_OK(status_or_page);
 
     PinnedPage& page = *status_or_page;

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -214,7 +214,7 @@ class VolumeTest : public ::testing::Test
     bool ok = true;
 
     llfs::StatusOr<llfs::PinnedPage> loaded =
-        this->page_cache->get(page_id, llfs::OkIfNotFound{false});
+        this->page_cache->get_page(page_id, llfs::OkIfNotFound{false});
 
     EXPECT_TRUE(loaded.ok());
     if (!loaded.ok()) {

--- a/src/llfs/volume_reader.cpp
+++ b/src/llfs/volume_reader.cpp
@@ -76,13 +76,13 @@ void VolumeReader::prefetch_hint(PageId page_id) /*override*/
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PinnedPage> VolumeReader::get(PageId page_id,
-                                       const Optional<PageLayoutId>& required_layout,
-                                       PinPageToJob pin_page_to_job,
-                                       OkIfNotFound ok_if_not_found) /*override*/
+StatusOr<PinnedPage> VolumeReader::get_page_with_layout_in_job(
+    PageId page_id, const Optional<PageLayoutId>& required_layout, PinPageToJob pin_page_to_job,
+    OkIfNotFound ok_if_not_found) /*override*/
 {
   BATT_UNTESTED_LINE();
-  return this->impl_->job_->get(page_id, required_layout, pin_page_to_job, ok_if_not_found);
+  return this->impl_->job_->get_page_with_layout_in_job(page_id, required_layout, pin_page_to_job,
+                                                        ok_if_not_found);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/volume_reader.hpp
+++ b/src/llfs/volume_reader.hpp
@@ -65,10 +65,20 @@ class VolumeReader : public PageLoader
   //+++++++++++-+-+--+----- --- -- -  -  -   -
   // PageLoader methods
   //
+  using PageLoader::get_page;
+  using PageLoader::get_page_in_job;
+  using PageLoader::get_page_slot;
+  using PageLoader::get_page_slot_in_job;
+  using PageLoader::get_page_slot_with_layout;
+  using PageLoader::get_page_slot_with_layout_in_job;
+  using PageLoader::get_page_with_layout;
+
   void prefetch_hint(PageId page_id) override;
 
-  StatusOr<PinnedPage> get(PageId page_id, const Optional<PageLayoutId>& required_layout,
-                           PinPageToJob pin_page_to_job, OkIfNotFound ok_if_not_found) override;
+  StatusOr<PinnedPage> get_page_with_layout_in_job(PageId page_id,
+                                                   const Optional<PageLayoutId>& required_layout,
+                                                   PinPageToJob pin_page_to_job,
+                                                   OkIfNotFound ok_if_not_found) override;
   //
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 


### PR DESCRIPTION
Fixes #40 

This one is pretty straightforward.   A few notes:

- This PR changes some primitive types in declarations to use the aliases in `<llfs/int_types.hpp>` (which are preferred for the project)
- In the case of PageLoader, I also took the opportunity to give distinct names to all of the overloads of the `get` function; this makes accidental shadowing much less likely, and so is definitely in the spirit of this PR (and of #40)
- Since this introduces breaking changes, we will need to do a minor version rev for the next release (if we were at major version >0, then interfaces would be considered stable and we would need a major rev, but since we are still 0.x.y, a minor rev is fine)