### PR TITLE
Upgrade to batteries/0.34.1.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class LlfsConan(ConanFile):
         "boost/1.81.0",
         "openssl/3.1.0",
         "glog/0.6.0",
-        "batteries/0.33.1@batteriescpp+batteries/stable",
+        "batteries/0.34.1@batteriescpp+batteries/stable",
         "cli11/2.3.2",
         "zlib/1.2.13",
     ] + ([
@@ -64,7 +64,8 @@ class LlfsConan(ConanFile):
     def configure(self):
         self.options["gtest"].shared = False
         self.options["boost"].shared = False
-        self.options["batteries"].glog_support = True
+        self.options["batteries"].with_glog = True
+        self.options["batteries"].header_only = False
 
     def build(self):
         cmake = CMake(self)

--- a/src/llfs/ioring_log_flush_op.test.hpp
+++ b/src/llfs/ioring_log_flush_op.test.hpp
@@ -10,6 +10,11 @@
 #ifndef LLFS_IORING_LOG_FLUSH_OP_TEST_HPP
 #define LLFS_IORING_LOG_FLUSH_OP_TEST_HPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/buffer.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/ioring_log_flush_op.hpp>
@@ -198,8 +203,10 @@ class FakeLogState
   }
 
   Status write_data(i64 file_offset, ConstBuffer src, std::function<bool()> inject_block_failure,
-                    usize flush_op_index)
+                    usize /*flush_op_index*/)
   {
+    //TODO [tastolfi 2023-05-22] use/verify `flush_op_index` arg
+
     const i64 end_file_offset = file_offset + BATT_CHECKED_CAST(i64, src.size());
 
     // Make sure the entire range of written data is within the range of valid disk blocks.
@@ -665,5 +672,7 @@ class ExpectedFlushOpState
 };  // namespace llfs
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_IORING_LOG_FLUSH_OP_TEST_HPP

--- a/src/llfs/ioring_log_initializer.cpp
+++ b/src/llfs/ioring_log_initializer.cpp
@@ -9,6 +9,8 @@
 #include <llfs/ioring_log_initializer.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring_log_initializer.ipp>
 #include <llfs/logging.hpp>
 
@@ -21,7 +23,7 @@ template class BasicIoRingLogInitializer<IoRing>;
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 Status initialize_ioring_log_device(RawBlockFile& file, const IoRingLogConfig& config,
-                                    ConfirmThisWillEraseAllMyData confirm)
+                                    ConfirmThisWillEraseAllMyData /*confirm*/)
 {
   LLFS_VLOG(1) << "initializing IoRingLogDevice; " << BATT_INSPECT(config.block_count())
                << BATT_INSPECT(config.block_size()) << BATT_INSPECT(config.block_capacity());
@@ -72,3 +74,5 @@ Status initialize_ioring_log_device(RawBlockFile& file, const IoRingLogConfig& c
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/memory_page_cache.cpp
+++ b/src/llfs/memory_page_cache.cpp
@@ -19,7 +19,7 @@ namespace llfs {
 
 batt::SharedPtr<PageCache> make_memory_page_cache(
     batt::TaskScheduler& scheduler, const std::vector<std::pair<PageCount, PageSize>>& arena_sizes,
-    MaxRefsPerPage max_refs_per_page)
+    MaxRefsPerPage /*max_refs_per_page*/)  // TODO [tastolfi 2023-05-22] use max_refs_per_page
 {
   std::unordered_map<PageSize, PageCount, PageSize::Hash> dedup;
   for (const auto& [count, size] : arena_sizes) {

--- a/src/llfs/packed_status.cpp
+++ b/src/llfs/packed_status.cpp
@@ -31,7 +31,7 @@ usize packed_sizeof(const batt::Status& status)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<batt::Status> unpack_object(const PackedStatus& packed_status, DataReader*)
+StatusOr<batt::Status> unpack_object(const PackedStatus& /*packed_status*/, DataReader*)
 {
   // This is complicated by the fact that the remote group type may not have been registered
   // locally.  TODO [tastolfi 2022-11-04]

--- a/src/llfs/page_allocator_state.cpp
+++ b/src/llfs/page_allocator_state.cpp
@@ -487,10 +487,9 @@ batt::Status PageAllocatorState::recover(const SlotRange& slot_offset,
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 template <bool kInsideRecovery>
-void PageAllocatorState::process_txn(const SlotRange& slot_offset,
-                                     const PackedPageAllocatorTxn& txn,
-                                     PageAllocatorMetrics* metrics,
-                                     std::integral_constant<bool, kInsideRecovery> inside_recovery)
+void PageAllocatorState::process_txn(
+    const SlotRange& slot_offset, const PackedPageAllocatorTxn& txn, PageAllocatorMetrics* metrics,
+    std::integral_constant<bool, kInsideRecovery> /*inside_recovery*/)
 {
   LLFS_VLOG(1) << "(device=" << this->page_ids_.get_device_id()  //
                << ") " << (kInsideRecovery ? "recovering" : "learning") << "[slot=" << slot_offset

--- a/src/llfs/page_arena_config.cpp
+++ b/src/llfs/page_arena_config.cpp
@@ -71,14 +71,14 @@ Status configure_storage_object(StorageFileBuilder::Transaction& txn,
                       },
 
                       //----- --- -- -  -  -   -
-                      [&](const LinkToExistingPageDevice& opts) -> Status {
+                      [&](const LinkToExistingPageDevice& /*opts*/) -> Status {
                         LLFS_LOG_ERROR() << "Config not supported: arena.page_device = CreateNew, "
                                             "arena.page_allocator.page_device = LinkToExisting";
                         return batt::StatusCode::kInvalidArgument;
                       },
 
                       //----- --- -- -  -  -   -
-                      [&](const LinkToNewPageDevice& opts) -> Status {
+                      [&](const LinkToNewPageDevice& /*opts*/) -> Status {
                         link_new_page_device = true;
                         return OkStatus();
                       });
@@ -112,7 +112,7 @@ Status configure_storage_object(StorageFileBuilder::Transaction& txn,
           },
 
           //----- --- -- -  -  -   -
-          [&](const LinkToNewPageDevice& link_to_new) -> StatusOr<boost::uuids::uuid> {
+          [&](const LinkToNewPageDevice& /*link_to_new*/) -> StatusOr<boost::uuids::uuid> {
             LLFS_LOG_ERROR() << "Config not supported: arena.page_device = LinkToNew";
             return {batt::StatusCode::kInvalidArgument};
           }));
@@ -170,7 +170,7 @@ Status configure_storage_object(StorageFileBuilder::Transaction& txn,
 //
 StatusOr<PageArena> recover_storage_object(
     const batt::SharedPtr<StorageContext>& storage_context,       //
-    const std::string& file_name,                                 //
+    const std::string& /*file_name*/,                             //
     const FileOffsetPtr<const PackedPageArenaConfig&>& p_config,  //
     const PageAllocatorRuntimeOptions& allocator_options,         //
     const IoRingLogDriverOptions& allocator_log_options,          //

--- a/src/llfs/page_arena_file.cpp
+++ b/src/llfs/page_arena_file.cpp
@@ -34,19 +34,19 @@ namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-auto driver_config_from_arena_config(const FileOffsetPtr<PackedPageArenaConfig>& config)
+auto driver_config_from_arena_config(const FileOffsetPtr<PackedPageArenaConfig>& /*config*/)
 {
   return;
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<PageArena> open_page_device_file_impl(batt::TaskScheduler& scheduler, IoRing& ioring,
-                                               const FileSegmentRef& file_ref,
-                                               const PageArenaFileRuntimeOptions& options,
-                                               PackedPageArenaConfig* config, bool write_config,
-                                               ConfirmThisWillEraseAllMyData confirm)
+StatusOr<PageArena> open_page_device_file_impl(
+    batt::TaskScheduler& /*scheduler*/, IoRing& /*ioring*/, const FileSegmentRef& /*file_ref*/,
+    const PageArenaFileRuntimeOptions& /*options*/, PackedPageArenaConfig* /*config*/,
+    bool /*write_config*/, ConfirmThisWillEraseAllMyData /*confirm*/)
 {
+  //TODO [tastolfi 2023-05-22] implement me!
   return {batt::StatusCode::kUnimplemented};
 }
 
@@ -58,7 +58,8 @@ StatusOr<PageArena> page_arena_from_file(batt::TaskScheduler& scheduler, IoRing&
                                          PackedPageArenaConfig* config_out)
 {
   return open_page_device_file_impl(scheduler, ioring, file_ref, options, config_out,
-                                    /*write_config=*/false, ConfirmThisWillEraseAllMyData::kNo);
+                                    /*write_config=*/
+                                    false, ConfirmThisWillEraseAllMyData::kNo);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -66,7 +67,7 @@ StatusOr<PageArena> page_arena_from_file(batt::TaskScheduler& scheduler, IoRing&
 StatusOr<PageArena> initialize_page_arena_file(batt::TaskScheduler& scheduler, IoRing& ioring,
                                                const FileSegmentRef& file_ref,
                                                const PageArenaFileRuntimeOptions& options,
-                                               const PackedPageArenaConfig& config,
+                                               const PackedPageArenaConfig& /*config*/,
                                                ConfirmThisWillEraseAllMyData confirm)
 {
   if (confirm != ConfirmThisWillEraseAllMyData::kYes) {
@@ -84,8 +85,9 @@ StatusOr<PageArena> initialize_page_arena_file(batt::TaskScheduler& scheduler, I
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 StatusOr<std::vector<std::unique_ptr<PageArenaConfigInFile>>> read_arena_configs_from_file(
-    const std::string& filename)
+    const std::string& /*filename*/)
 {
+  //TODO [tastolfi 2023-05-22] implement me!
   return {batt::StatusCode::kUnimplemented};
 }
 

--- a/src/llfs/page_recycler.cpp
+++ b/src/llfs/page_recycler.cpp
@@ -8,7 +8,7 @@
 
 #include <batteries/suppress.hpp>
 
-BATT_SUPPRESS("-Wmaybe-uninitialized")
+BATT_SUPPRESS_IF_GCC("-Wmaybe-uninitialized")
 
 #include <llfs/page_recycler.hpp>
 //
@@ -145,9 +145,9 @@ StatusOr<SlotRange> refresh_recycler_info_slot(TypedSlotWriter<PageRecycleEvent>
   //
   BATT_ASSIGN_OK_RESULT(Optional<PageRecycler::Batch> latest_batch, visitor.consume_latest_batch());
 
-  auto state = std::make_unique<State>(
-      visitor.recycler_uuid(), latest_info_refresh_slot->lower_bound, visitor.options(),
-      recovered_log->get()->capacity(), recovered_log->get()->slot_range(LogReadMode::kDurable));
+  auto state =
+      std::make_unique<State>(visitor.recycler_uuid(), latest_info_refresh_slot->lower_bound,
+                              visitor.options(), recovered_log->get()->capacity());
 
   state->bulk_load(as_slice(visitor.recovered_pages()));
 
@@ -758,4 +758,4 @@ Status PageRecycler::trim_log()
 
 }  // namespace llfs
 
-BATT_UNSUPPRESS()
+BATT_UNSUPPRESS_IF_GCC()

--- a/src/llfs/page_recycler.test.cpp
+++ b/src/llfs/page_recycler.test.cpp
@@ -646,7 +646,7 @@ TEST_F(PageRecyclerTest, DuplicatePageDeletion)
                                  /*recycle_grant=*/testing::_, /*recycle_depth=*/0))
             .WillOnce(::testing::Invoke(
                 [&](const batt::Slice<const llfs::PageToRecycle>& to_delete,
-                    llfs::PageRecycler& recycler, llfs::slot_offset_type caller_slot,
+                    llfs::PageRecycler& /*recycler*/, llfs::slot_offset_type /*caller_slot*/,
                     batt::Grant& recycle_grant, i32 recycle_depth) -> batt::Status {
                   LLFS_VLOG(1) << "First delete: " << batt::dump_range(to_delete)
                                << BATT_INSPECT(this->p_mem_log_->driver().get_trim_pos());
@@ -680,8 +680,8 @@ TEST_F(PageRecyclerTest, DuplicatePageDeletion)
                                      /*recycle_grant=*/testing::_, /*recycle_depth=*/1))
                 .WillOnce(::testing::Invoke(
                     [&](const batt::Slice<const llfs::PageToRecycle>& to_delete,
-                        llfs::PageRecycler& recycler, llfs::slot_offset_type caller_slot,
-                        batt::Grant& recycle_grant, i32 recycle_depth) -> batt::Status {
+                        llfs::PageRecycler& /*recycler*/, llfs::slot_offset_type /*caller_slot*/,
+                        batt::Grant& /*recycle_grant*/, i32 /*recycle_depth*/) -> batt::Status {
                       LLFS_VLOG(1) << "Second delete: " << batt::dump_range(to_delete)
                                    << BATT_INSPECT(this->p_mem_log_->driver().get_trim_pos());
 
@@ -734,9 +734,11 @@ TEST_F(PageRecyclerTest, DuplicatePageDeletion)
                                  /*recycle_grant=*/testing::_, /*recycle_depth=*/0))
             .WillRepeatedly(::testing::Invoke(
                 [&](const batt::Slice<const llfs::PageToRecycle>& to_delete,
-                    llfs::PageRecycler& recycler, llfs::slot_offset_type caller_slot,
-                    batt::Grant& recycle_grant, i32 recycle_depth) -> batt::Status  //
+                    llfs::PageRecycler& /*recycler*/, llfs::slot_offset_type /*caller_slot*/,
+                    batt::Grant& /*recycle_grant*/, i32 /*recycle_depth*/) -> batt::Status  //
                 {
+                  // TODO [tastolfi 2023-05-22] check more of the inputs to this function
+
                   LLFS_VLOG(1) << "Post-recovery delete: " << batt::dump_range(to_delete);
 
                   for (const llfs::PageToRecycle& p : to_delete) {

--- a/src/llfs/page_recycler_state.cpp
+++ b/src/llfs/page_recycler_state.cpp
@@ -26,8 +26,7 @@ usize max_pages_for_wal_capacity(const PageRecyclerOptions& options, usize wal_c
 //
 PageRecycler::State::State(const boost::uuids::uuid& uuid,
                            slot_offset_type latest_info_refresh_slot,
-                           const PageRecyclerOptions& options, usize wal_capacity,
-                           const SlotRange& initial_wal_range)
+                           const PageRecyclerOptions& options, usize wal_capacity)
     : NoLockState{uuid, latest_info_refresh_slot, options}
     , arena_used_{0}
     , arena_size_{max_pages_for_wal_capacity(options, wal_capacity)}

--- a/src/llfs/page_recycler_state.hpp
+++ b/src/llfs/page_recycler_state.hpp
@@ -55,8 +55,7 @@ class PageRecycler::State : public PageRecycler::NoLockState
   using ThreadSafeBase = NoLockState;
 
   explicit State(const boost::uuids::uuid& uuid, slot_offset_type latest_info_refresh_slot,
-                 const PageRecyclerOptions& options, usize wal_capacity,
-                 const SlotRange& initial_wal_range);
+                 const PageRecyclerOptions& options, usize wal_capacity);
 
   //+++++++++++-+-+--+----- --- -- -  -  -   --
 

--- a/src/llfs/slot_reader.hpp
+++ b/src/llfs/slot_reader.hpp
@@ -169,7 +169,7 @@ class TypedSlotReader<PackedVariant<Ts...>> : public SlotReader
 
     const bool ok = data_reader.read_variant(  //
         batt::StaticType<PackedVariant<Ts...>>{},
-        [&](const PackedVariant<Ts...>& head, const auto& tail) {
+        [&](const PackedVariant<Ts...>& /*head*/, const auto& tail) {
           auto unpacked_object = unpack_object(tail, &data_reader);
 
           if (!unpacked_object.ok()) {

--- a/src/llfs/slot_writer.cpp
+++ b/src/llfs/slot_writer.cpp
@@ -59,8 +59,7 @@ void SlotWriter::halt()
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-auto SlotWriter::prepare(batt::Grant& caller_grant, usize slot_body_size,
-                         Optional<std::string_view> name) -> StatusOr<Append>
+auto SlotWriter::prepare(batt::Grant& caller_grant, usize slot_body_size) -> StatusOr<Append>
 {
   BATT_CHECK_NE(slot_body_size, 0);
 
@@ -83,7 +82,6 @@ auto SlotWriter::prepare(batt::Grant& caller_grant, usize slot_body_size,
       std::move(*slot_grant),
       *slot_buffer,
       slot_body_size,
-      name,
   }};
 }
 
@@ -91,7 +89,7 @@ auto SlotWriter::prepare(batt::Grant& caller_grant, usize slot_body_size,
 //
 SlotWriter::Append::Append(SlotWriter* that, batt::Mutex<LogDevice::Writer*>::Lock writer_lock,
                            batt::Grant&& slot_grant, const MutableBuffer& slot_buffer,
-                           usize slot_body_size, Optional<std::string_view> name) noexcept
+                           usize slot_body_size) noexcept
     : that_{that}
     , writer_lock_{std::move(writer_lock)}
     , slot_grant_{std::move(slot_grant)}

--- a/src/llfs/storage_file_builder.ipp
+++ b/src/llfs/storage_file_builder.ipp
@@ -72,7 +72,7 @@ StatusOr<FileOffsetPtr<const PackedConfigT&>> StorageFileBuilder::Transaction::a
 //
 template <typename ConfigOptionsT, typename PackedConfigT>
 StatusOr<FileOffsetPtr<PackedConfigT&>> StorageFileBuilder::Transaction::add_config_slot(
-    const ConfigOptionsT& options)
+    const ConfigOptionsT& /*options*/)
 {
   verify_config_slot_type_requirements<PackedConfigT>();
 

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -172,15 +172,15 @@ class VolumeTest : public ::testing::Test
     for (;;) {
       llfs::StatusOr<usize> n_slots_visited = reader.visit_typed_next(
           batt::WaitForResource::kFalse,
-          [&data](const llfs::SlotParse& slot, const UpsertEvent& event) {
+          [&data](const llfs::SlotParse& /*slot*/, const UpsertEvent& event) {
             data[event.key] = event.value;
             return llfs::OkStatus();
           },
-          [&data](const llfs::SlotParse& slot, const RemoveEvent& event) {
+          [&data](const llfs::SlotParse& /*slot*/, const RemoveEvent& event) {
             data.erase(event.key);
             return llfs::OkStatus();
           },
-          [](const llfs::SlotParse& slot, const llfs::BoxedSeq<llfs::PageId>&) {
+          [](const llfs::SlotParse& /*slot*/, const llfs::BoxedSeq<llfs::PageId>&) {
             return llfs::OkStatus();
           });
 
@@ -306,7 +306,7 @@ TEST_F(VolumeTest, RecoverEmptyVolume)
 
       std::unique_ptr<llfs::Volume> test_volume = this->open_volume_or_die(
           fake_root_log, fake_recycler_log,
-          /*slot_visitor_fn=*/[](const llfs::SlotParse&, const std::string_view& user_data) {
+          /*slot_visitor_fn=*/[](const llfs::SlotParse&, const std::string_view& /*user_data*/) {
             return llfs::OkStatus();
           });
 
@@ -1040,7 +1040,7 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
 //
 auto VolumeSimTest::get_slot_visitor()
 {
-  return [this](const llfs::SlotParse slot, const llfs::PageId& page_id) {
+  return [this](const llfs::SlotParse /*slot*/, const llfs::PageId& page_id) {
     if (page_id == this->first_page_id) {
       this->recovered_first_page = true;
     } else if (page_id == this->second_root_page_id) {
@@ -1289,7 +1289,7 @@ void VolumeSimTest::verify_post_recovery_expectations(llfs::StorageSimulation& s
 //
 batt::StatusOr<llfs::PageId> VolumeSimTest::build_page_with_refs_to(
     const std::vector<llfs::PageId>& referenced_page_ids, llfs::PageSize page_size,
-    llfs::PageCacheJob& job, llfs::StorageSimulation& sim)
+    llfs::PageCacheJob& job, llfs::StorageSimulation& /*sim*/)
 {
   batt::StatusOr<llfs::PageGraphNodeBuilder> page_builder =
       llfs::PageGraphNodeBuilder::from_new_page(

--- a/src/llfs/volume_config.cpp
+++ b/src/llfs/volume_config.cpp
@@ -77,7 +77,7 @@ Status configure_storage_object(StorageFileBuilder::Transaction& txn,
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 StatusOr<std::unique_ptr<Volume>> recover_storage_object(
-    const batt::SharedPtr<StorageContext>& storage_context, const std::string file_name,
+    const batt::SharedPtr<StorageContext>& storage_context, const std::string /*file_name*/,
     const FileOffsetPtr<const PackedVolumeConfig&>& p_volume_config,
     VolumeRuntimeOptions&& volume_runtime_options)
 {

--- a/src/llfs/volume_events.cpp
+++ b/src/llfs/volume_events.cpp
@@ -150,7 +150,8 @@ PackedTrimmedPrepareJob* pack_object_to(const TrimmedPrepareJob& object,
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<TrimmedPrepareJob> unpack_object(const PackedTrimmedPrepareJob& packed, DataReader* src)
+StatusOr<TrimmedPrepareJob> unpack_object(const PackedTrimmedPrepareJob& packed,
+                                          DataReader* /*src*/)
 {
   TrimmedPrepareJob object;
 

--- a/src/llfs/volume_trimmer.cpp
+++ b/src/llfs/volume_trimmer.cpp
@@ -474,8 +474,10 @@ Status refresh_volume_metadata(TypedSlotWriter<VolumeEventVariant>& slot_writer,
 StatusOr<VolumeTrimEventInfo> write_trim_event(TypedSlotWriter<VolumeEventVariant>& slot_writer,
                                                batt::Grant& grant,
                                                VolumeTrimmedRegionInfo& trimmed_region,
-                                               VolumePendingJobsUMap& prior_pending_jobs)
+                                               VolumePendingJobsUMap& /*prior_pending_jobs*/)
 {
+  // TODO [tastolfi 2023-05-22] use or remove `prior_pending_jobs` arg
+
   VolumeTrimEvent event;
 
   event.old_trim_pos = trimmed_region.slot_range.lower_bound;

--- a/src/llfs/volume_trimmer.test.cpp
+++ b/src/llfs/volume_trimmer.test.cpp
@@ -18,6 +18,8 @@
 #include <llfs/testing/fake_log_device.hpp>
 #include <llfs/uuid.hpp>
 
+#include <batteries/async/fake_execution_context.hpp>
+#include <batteries/async/fake_executor.hpp>
 #include <batteries/env.hpp>
 
 #include <random>
@@ -306,7 +308,9 @@ class VolumeTrimmerTest : public ::testing::Test
     batt::StatusOr<usize> n_read = slot_reader.run(
         batt::WaitForResource::kFalse,
         batt::make_case_of_visitor(
-            [&](const llfs::SlotParse& slot, const llfs::VolumeTrimEvent& trim_event) {
+            [&](const llfs::SlotParse& /*slot*/, const llfs::VolumeTrimEvent& trim_event) {
+              // TODO [tastolfi 2023-05-22] use/verify `slot` arg
+
               for (auto iter = this->committed_jobs.begin(); iter != this->committed_jobs.end();
                    iter = this->committed_jobs.erase(iter)) {
                 const auto& [prepare_slot, page_ids] = *iter;


### PR DESCRIPTION
This speeds up build times by ~35% because Batteries is now non-header-only by default.  Some warnings that were being masked by the header-only version of Batteries were triggered, which caused all the changes to comment out arg names in a bunch of places.