### PR TITLE
Upgrade batteries, fix compilation issues re: clang.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 #+++++++++++-+-+--+----- --- -- -  -  -   -
 # See batteries/docker/Dockerfile (https://gitlab.com/batteriescpp/batteries/)
 #
-image: registry.gitlab.com/batteriescpp/batteries:v0.30.2.linux_gcc11_amd64
+image: registry.gitlab.com/batteriescpp/batteries:v0.34.7-devel.linux_gcc11_amd64@sha256:799fb68bb0d8236d5873e6586c684189374b70717ce8d8d00359ea9e747a8afb
 
 variables:
   GIT_STRATEGY: clone

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ endif
 
 BUILD_DIR := build/$(BUILD_TYPE)
 
+export PROJECT_DIR=$(shell pwd)
+
 TCMALLOC_ENV := $(shell find /lib/ -name '*tcmalloc.so*' | sort -Vr | head -1 | xargs -I{} echo LD_PRELOAD={})
 $(info TCMALLOC_ENV=$(TCMALLOC_ENV))
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class LlfsConan(ConanFile):
         "gtest/1.13.0",
         "boost/1.81.0",
         "glog/0.6.0",
-        "batteries/0.34.1@batteriescpp+batteries/stable",
+        "batteries/0.34.10@batteriescpp+batteries/stable",
         "cli11/2.3.2",
 
         # Version overrides (conflict resolutions)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(LLFS CXX)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_definitions("-fno-diagnostics-color")
 
 #==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -               

--- a/src/llfs/bloom_filter.hpp
+++ b/src/llfs/bloom_filter.hpp
@@ -46,7 +46,7 @@ inline seq::LoopControl hash_for_bloom(const T& item, u64 count, Fn&& fn)
       0x0c38ccabc94a487full, 0x43e19e80ee4fe6edull, 0x22699c9fc26f20eeull, 0xa559cbafff2cea37ull};
 
   const u64 item_hash = boost::hash<T>{}(item);
-  u64 seed = item_hash;
+  usize seed = item_hash;
   for (u64 i = 0; i < count; ++i) {
     boost::hash_combine(seed, kSeeds[i % 32] + i / 32);
     boost::hash_combine(seed, item_hash);
@@ -221,7 +221,7 @@ void parallel_build_bloom_filter(batt::WorkerPool& worker_pool, Iter first, Iter
                  auto src_begin = std::next(first, task_offset);
                  return
                      [src = boost::make_iterator_range(src_begin, std::next(src_begin, task_size)),
-                      dst = temp_filters[task_index], hash_fn, filter] {
+                      dst = temp_filters[task_index], hash_fn] {
                        dst->clear();
                        for (const auto& item : src) {
                          dst->insert(hash_fn(item));

--- a/src/llfs/cache.hpp
+++ b/src/llfs/cache.hpp
@@ -481,7 +481,7 @@ class CacheSlot
 
     BATT_CHECK(this->is_pinned(new_state));
 
-    BATT_SUPPRESS("-Wmaybe-uninitialized")
+    BATT_SUPPRESS_IF_GCC("-Wmaybe-uninitialized")
 
     // We must always do this, even if the pin fails, so that we don't have an unmatched
     // `remove_ref` in `release_pin` below.
@@ -505,7 +505,7 @@ class CacheSlot
       this->notify_pinned(new_state);
     }
 
-    BATT_UNSUPPRESS()
+    BATT_UNSUPPRESS_IF_GCC()
 
     return PinnedCacheSlot<K, V>{this};
   }

--- a/src/llfs/cache.test.cpp
+++ b/src/llfs/cache.test.cpp
@@ -122,7 +122,9 @@ TEST(CacheTest, Basic)
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   // Test PinnedSlot copy assign to self.
   //
+  BATT_SUPPRESS_IF_CLANG("-Wself-assign-overloaded")
   slot2_copy4 = slot2_copy4;
+  BATT_UNSUPPRESS_IF_CLANG()
 
   EXPECT_TRUE(slot2_copy4);
   EXPECT_THAT(*slot2_copy4, ::testing::StrEq("foo2"));
@@ -130,7 +132,9 @@ TEST(CacheTest, Basic)
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   // Test PinnedSlot move assign to self.
   //
+  BATT_SUPPRESS_IF_CLANG("-Wself-move")
   slot2_copy4 = std::move(slot2_copy4);
+  BATT_UNSUPPRESS_IF_CLANG()
 
   EXPECT_TRUE(slot2_copy4);
   EXPECT_THAT(*slot2_copy4, ::testing::StrEq("foo2"));

--- a/src/llfs/config.hpp
+++ b/src/llfs/config.hpp
@@ -20,6 +20,28 @@
 
 namespace llfs {
 
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+#ifdef __APPLE__
+#define LLFS_PLATFORM_IS_APPLE 1
+#else
+#undef LLFS_PLATFORM_IS_APPLE
+#endif
+
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+#ifdef __linux__
+#define LLFS_PLATFORM_IS_LINUX 1
+#else
+#undef LLFS_PLATFORM_IS_LINUX
+#endif
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+
+#if !LLFS_PLATFORM_IS_LINUX
+#define LLFS_DISABLE_IO_URING 1
+#endif
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+
 // Set to 1 to disable crc generation for pages.
 //
 #define LLFS_DISABLE_PAGE_CRC 1

--- a/src/llfs/define_packed_type.hpp
+++ b/src/llfs/define_packed_type.hpp
@@ -45,12 +45,12 @@ using UnpackedTypeFor = batt::RemoveStatusOr<decltype(unpack_object(std::declval
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
 #define LLFS_DEFINE_PACKED_TYPE_FOR(type, packed_type)                                             \
-  inline [[maybe_unused]] ::batt::StaticType<packed_type> llfs_packed_type_for(                    \
+  [[maybe_unused]] inline ::batt::StaticType<packed_type> llfs_packed_type_for(                    \
       ::batt::StaticType<type>)                                                                    \
   {                                                                                                \
     return {};                                                                                     \
   }                                                                                                \
-  static inline [[maybe_unused]] constexpr int BOOST_PP_CAT(                                       \
+  [[maybe_unused]] static inline constexpr int BOOST_PP_CAT(                                       \
       Suppress_Warning_About_Extra_Semicolon_After_LLFS_DEFINE_PACKED_TYPE_FOR_,                   \
       BOOST_PP_CAT(__COUNTER__, BOOST_PP_CAT(_, __LINE__))) = 0
 

--- a/src/llfs/filesystem.cpp
+++ b/src/llfs/filesystem.cpp
@@ -41,7 +41,11 @@ StatusOr<int> open_file_read_write(std::string_view file_name, OpenForAppend ope
     flags |= O_APPEND;
   }
   if (open_raw_io) {
+#ifdef LLFS_PLATFORM_IS_LINUX
     flags |= O_DIRECT | O_SYNC;
+#else
+    LLFS_LOG_WARNING() << "open_raw_io only supported on Linux!";
+#endif
   }
   const int fd = syscall_retry([&] {
     return ::open(std::string(file_name).c_str(), flags);
@@ -296,6 +300,8 @@ Status update_file_status_flags(int fd, EnableFileFlags enable_flags,
 //
 Status enable_raw_io_fd(int fd, bool enabled)
 {
+#ifdef LLFS_PLATFORM_IS_LINUX  //----- --- -- -  -  -   -
+
   // TODO [tastolfi 2022-06-21] Add O_SYNC/O_DSYNC to the flags masks below once Linux supports this
   // (https://man7.org/linux/man-pages/man2/fcntl.2.html#BUGS)
   //
@@ -304,6 +310,17 @@ Status enable_raw_io_fd(int fd, bool enabled)
   } else {
     return update_file_status_flags(fd, EnableFileFlags{0}, DisableFileFlags{O_DIRECT});
   }
+
+#else  //----- --- -- -  -  -   -
+
+  (void)fd;
+  (void)enabled;
+
+  LLFS_LOG_WARNING() << "enable_raw_io_fd only supported on Linux!";
+
+  return OkStatus();
+
+#endif  //----- --- -- -  -  -   -
 }
 
 }  // namespace llfs

--- a/src/llfs/ioring_log_config.cpp
+++ b/src/llfs/ioring_log_config.cpp
@@ -9,6 +9,8 @@
 #include <llfs/ioring_log_config.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/log_device_config.hpp>
 
 namespace llfs {
@@ -27,3 +29,5 @@ namespace llfs {
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/ioring_log_device.test.cpp
+++ b/src/llfs/ioring_log_device.test.cpp
@@ -10,6 +10,8 @@
 //
 #include <llfs/ioring_log_device.hpp>
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -148,3 +150,5 @@ TEST(IoringLogDeviceTest, StorageFile)
 }
 
 }  // namespace
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/ioring_log_driver.cpp
+++ b/src/llfs/ioring_log_driver.cpp
@@ -9,6 +9,8 @@
 #include <llfs/ioring_log_driver.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring_log_driver.ipp>
 
 namespace llfs {
@@ -16,3 +18,5 @@ namespace llfs {
 template class BasicIoRingLogDriver<BasicIoRingLogFlushOp>;
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/ioring_log_driver.hpp
+++ b/src/llfs/ioring_log_driver.hpp
@@ -10,6 +10,11 @@
 #ifndef LLFS_IORING_LOG_DRIVER_HPP
 #define LLFS_IORING_LOG_DRIVER_HPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/basic_log_storage_driver.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/ioring_log_config.hpp>
@@ -317,5 +322,7 @@ class BasicIoRingLogDriver
 };
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_IORING_LOG_DRIVER_HPP

--- a/src/llfs/ioring_log_driver.ipp
+++ b/src/llfs/ioring_log_driver.ipp
@@ -10,6 +10,11 @@
 #ifndef LLFS_IORING_LOG_DRIVER_IPP
 #define LLFS_IORING_LOG_DRIVER_IPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/data_reader.hpp>
 #include <llfs/ioring_log_driver.hpp>
 #include <llfs/ioring_log_initializer.hpp>
@@ -486,5 +491,7 @@ inline slot_offset_type BasicIoRingLogDriver<FlushOpImpl>::FlushState::get_flush
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_IORING_LOG_DRIVER_IPP

--- a/src/llfs/ioring_log_flush_op.ipp
+++ b/src/llfs/ioring_log_flush_op.ipp
@@ -10,6 +10,10 @@
 #ifndef LLFS_IORING_LOG_FLUSH_OP_IPP
 #define LLFS_IORING_LOG_FLUSH_OP_IPP
 
+#include <llfs/config.hpp>
+//
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring_log_flush_op.hpp>
 
 #include <llfs/metrics.hpp>
@@ -655,5 +659,7 @@ inline bool BasicIoRingLogFlushOp<DriverImpl>::fill_buffer(slot_offset_type know
 #undef THIS_VLOG
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_IORING_LOG_FLUSH_OP_IPP

--- a/src/llfs/ioring_log_flush_op.test.cpp
+++ b/src/llfs/ioring_log_flush_op.test.cpp
@@ -12,15 +12,21 @@
 #include <llfs/ioring_log_flush_op.hpp>
 #include <llfs/ioring_log_flush_op.ipp>
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring_log_flush_op.test.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <llfs/buffer.hpp>
 #include <llfs/config.hpp>
 #include <llfs/constants.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/logging.hpp>
+#include <llfs/optional.hpp>
+#include <llfs/slot.hpp>
+#include <llfs/status.hpp>
 
 #include <batteries/checked_cast.hpp>
 #include <batteries/small_fn.hpp>
@@ -631,3 +637,5 @@ TEST(IoRingLogFlushOpTest, StateMachineSimulation)
 }
 
 }  // namespace
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/ioring_log_initializer.hpp
+++ b/src/llfs/ioring_log_initializer.hpp
@@ -10,6 +10,10 @@
 #ifndef LLFS_IORING_LOG_INITIALIZER_HPP
 #define LLFS_IORING_LOG_INITIALIZER_HPP
 
+#include <llfs/config.hpp>
+//
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/confirm.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/ioring.hpp>
@@ -125,5 +129,7 @@ class BasicIoRingLogInitializer
 };
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_IORING_LOG_INITIALIZER_HPP

--- a/src/llfs/ioring_log_initializer.ipp
+++ b/src/llfs/ioring_log_initializer.ipp
@@ -10,6 +10,10 @@
 #ifndef LLFS_IORING_LOG_INITIALIZER_IPP
 #define LLFS_IORING_LOG_INITIALIZER_IPP
 
+#include <llfs/config.hpp>
+//
+#ifndef LLFS_DISABLE_IO_URING
+
 namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -172,5 +176,7 @@ inline usize BasicIoRingLogInitializer<IoRingImpl>::Subtask::self_index() const
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_IORING_LOG_INITIALIZER_IPP

--- a/src/llfs/log_block_calculator.test.cpp
+++ b/src/llfs/log_block_calculator.test.cpp
@@ -30,7 +30,8 @@ TEST(LogBlockCalculator, Test)
   const usize log_size = 1 * kMiB;
 
   for (const usize queue_depth : {1, 2, 4, 4096}) {
-    for (const usize block_size : {usize{512}, 1 * kKiB, 16 * kKiB, 64 * kKiB}) {
+    for (const usize block_size :
+         {usize{512}, usize{1 * kKiB}, usize{16 * kKiB}, usize{64 * kKiB}}) {
       ASSERT_EQ(block_size % llfs::kLogPageSize, 0u);
 
       for (const i64 begin_file_offset : {i64(0), i64(llfs::kLogPageSize * 3)}) {

--- a/src/llfs/log_device_config.cpp
+++ b/src/llfs/log_device_config.cpp
@@ -9,6 +9,8 @@
 #include <llfs/log_device_config.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring_log_device.hpp>
 #include <llfs/ioring_log_initializer.hpp>
 #include <llfs/raw_block_file.hpp>
@@ -90,3 +92,5 @@ StatusOr<std::unique_ptr<IoRingLogDeviceFactory>> recover_storage_object(
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/log_device_config.hpp
+++ b/src/llfs/log_device_config.hpp
@@ -10,6 +10,11 @@
 #ifndef LLFS_PACKED_LOG_DEVICE_CONFIG_HPP
 #define LLFS_PACKED_LOG_DEVICE_CONFIG_HPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/constants.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/ioring_log_device.hpp>
@@ -218,5 +223,7 @@ struct PackedConfigTagFor<PackedLogDeviceConfig> {
 std::ostream& operator<<(std::ostream& out, const PackedLogDeviceConfig& t);
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_PACKED_LOG_DEVICE_CONFIG_HPP

--- a/src/llfs/packed_bytes.hpp
+++ b/src/llfs/packed_bytes.hpp
@@ -17,6 +17,7 @@
 
 #include <batteries/static_assert.hpp>
 
+#include <cstring>
 #include <string>
 #include <string_view>
 
@@ -48,6 +49,14 @@ struct PackedBytes {
   //
   PackedBytes(const PackedBytes&) = delete;
   PackedBytes& operator=(const PackedBytes&) = delete;
+
+  void clear() noexcept
+  {
+    this->data_offset = sizeof(PackedBytes);
+    this->unused_[0] = 0;
+    this->data_size = 0;
+    this->reserved_[0] = 0;
+  }
 
   const void* data() const
   {

--- a/src/llfs/packed_bytes.test.cpp
+++ b/src/llfs/packed_bytes.test.cpp
@@ -72,4 +72,36 @@ TEST(PackedBytesTest, UnpackCast)
   }
 }
 
+TEST(PackedBytesTest, Clear)
+{
+  char buffer[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  static_assert(sizeof(buffer) > sizeof(llfs::PackedBytes));
+
+  llfs::PackedBytes* p = reinterpret_cast<llfs::PackedBytes*>(buffer);
+
+  EXPECT_EQ(p->size(), 0x070605u) << BATT_INSPECT(batt::to_string(std::hex, p->size()));
+
+  buffer[2] = 0;
+
+  EXPECT_EQ(p->size(), 0x070605u) << BATT_INSPECT(batt::to_string(std::hex, p->size()));
+
+  buffer[1] = 0;
+
+  EXPECT_EQ(p->size(), 7u) << BATT_INSPECT(batt::to_string(std::hex, p->size()));
+
+  buffer[3] = 0;
+
+  EXPECT_EQ(p->size(), 7u) << BATT_INSPECT(batt::to_string(std::hex, p->size()));
+
+  buffer[0] = 0;
+
+  EXPECT_EQ(p->size(), 8u) << BATT_INSPECT(batt::to_string(std::hex, p->size()));
+
+  p->clear();
+
+  EXPECT_EQ(p->size(), 0u);
+  EXPECT_EQ(p->data(), (const void*)(buffer + sizeof(llfs::PackedBytes)));
+  EXPECT_THAT(p->as_str(), ::testing::StrEq(""));
+}
+
 }  // namespace

--- a/src/llfs/packed_config.hpp
+++ b/src/llfs/packed_config.hpp
@@ -95,7 +95,7 @@ struct alignas(512) PackedConfigBlock {
   static constexpr usize kPayloadCapacity =
       kSize - (64 /*offsetof(payload)*/ + 8 /*sizeof(crc64)*/);
 
-  static constexpr i64 kNullFileOffset = 0x7fffffffffffll;
+  static constexpr i64 kNullFileOffset = 0x7fffffffffffffffll;
 
   struct Flag {
     // TODO [tastolfi 2022-02-16]  define some flags...

--- a/src/llfs/packed_interval.hpp
+++ b/src/llfs/packed_interval.hpp
@@ -135,7 +135,7 @@ namespace batt {
 /** \brief Defines llfs::PackedBasicInterval to be the packed representation of batt::BasicInterval.
  */
 template <typename Traits>
-inline [[maybe_unused]] ::batt::StaticType<::llfs::PackedBasicInterval<Traits>>
+[[maybe_unused]] inline ::batt::StaticType<::llfs::PackedBasicInterval<Traits>>
     llfs_packed_type_for(::batt::StaticType<::batt::BasicInterval<Traits>>)
 {
   return {};

--- a/src/llfs/packed_status_or.hpp
+++ b/src/llfs/packed_status_or.hpp
@@ -145,7 +145,7 @@ batt::Status validate_packed_value(const llfs::PackedStatusOr<T>& packed, const 
 namespace batt {
 
 template <typename T, typename PackedT = ::llfs::PackedTypeFor<T>>
-inline [[maybe_unused]] ::batt::StaticType<::llfs::PackedStatusOr<PackedT>> llfs_packed_type_for(
+[[maybe_unused]] inline ::batt::StaticType<::llfs::PackedStatusOr<PackedT>> llfs_packed_type_for(
     ::batt::StaticType<StatusOr<T>>)
 {
   return {};

--- a/src/llfs/page_allocator.cpp
+++ b/src/llfs/page_allocator.cpp
@@ -24,10 +24,8 @@ namespace llfs {
 u64 PageAllocator::calculate_log_size(u64 physical_page_count, u64 max_attachments)
 {
   static const PackedPageRefCountRefresh packed_ref_count{
-      {
-          .page_id = {0},
-          .ref_count = 0,
-      },
+      .page_id = {0},
+      .ref_count = 0,
       .user_index = 0,
   };
   static const PackedPageAllocatorAttach packed_attachment{

--- a/src/llfs/page_allocator_config.cpp
+++ b/src/llfs/page_allocator_config.cpp
@@ -9,6 +9,8 @@
 #include <llfs/page_allocator_config.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/page_allocator.hpp>
 #include <llfs/uuid.hpp>
 
@@ -158,3 +160,5 @@ StatusOr<std::unique_ptr<PageAllocator>> recover_storage_object(
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/page_allocator_config.hpp
+++ b/src/llfs/page_allocator_config.hpp
@@ -10,12 +10,18 @@
 #ifndef LLFS_PAGE_ALLOCATOR_CONFIG_HPP
 #define LLFS_PAGE_ALLOCATOR_CONFIG_HPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
+#include <llfs/page_allocator_runtime_options.hpp>
+
 #include <llfs/int_types.hpp>
 #include <llfs/log_device_config.hpp>
 #include <llfs/optional.hpp>
 #include <llfs/packed_config.hpp>
 #include <llfs/packed_pointer.hpp>
-#include <llfs/page_allocator_runtime_options.hpp>
 #include <llfs/page_device_config.hpp>
 #include <llfs/page_size.hpp>
 
@@ -182,5 +188,7 @@ struct PackedConfigTagFor<PackedPageAllocatorConfig> {
 std::ostream& operator<<(std::ostream& out, const PackedPageAllocatorConfig& t);
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_PAGE_ALLOCATOR_CONFIG_HPP

--- a/src/llfs/page_allocator_events.cpp
+++ b/src/llfs/page_allocator_events.cpp
@@ -29,7 +29,7 @@ std::ostream& operator<<(std::ostream& out, const PackedPageAllocatorDetach& t)
 //
 std::ostream& operator<<(std::ostream& out, const PackedPageRefCountRefresh& t)
 {
-  return out << "{" << static_cast<const PackedPageRefCount&>(t) << ", user_index=" << t.user_index
+  return out << "{" << PackedPageRefCount{t.page_id, t.ref_count} << ", user_index=" << t.user_index
              << ",}";
 }
 

--- a/src/llfs/page_allocator_events.hpp
+++ b/src/llfs/page_allocator_events.hpp
@@ -15,6 +15,7 @@
 #include <llfs/array_packer.hpp>
 #include <llfs/data_layout.hpp>
 #include <llfs/packed_page_ref_count.hpp>
+#include <llfs/packed_page_user_slot.hpp>
 #include <llfs/slot.hpp>
 #include <llfs/slot_writer.hpp>
 
@@ -94,7 +95,9 @@ bool pack_object_to(const PackedPageAllocatorDetach& from, PackedPageAllocatorDe
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-struct PackedPageRefCountRefresh : PackedPageRefCount {
+struct PackedPageRefCountRefresh {
+  PackedPageId page_id;
+  little_i32 ref_count;
   little_u32 user_index;
 };
 
@@ -165,16 +168,14 @@ inline usize packed_sizeof(const PackedPageAllocatorTxn& txn)
 inline usize packed_sizeof_checkpoint(const PackedPageAllocatorTxn& txn)
 {
   static const PackedPageRefCountRefresh packed_ref_count{
-      {
-          .page_id = {0},
-          .ref_count = 0,
-      },
+      .page_id = {.id_val = 0},
+      .ref_count = 0,
       .user_index = 0,
   };
   static const PackedPageAllocatorAttach packed_attachment{
       .user_slot =
           {
-              .user_id = {},
+              .user_id = boost::uuids::uuid(),
               .slot_offset = 0,
           },
       .user_index = 0,

--- a/src/llfs/page_allocator_state.cpp
+++ b/src/llfs/page_allocator_state.cpp
@@ -67,10 +67,11 @@ StatusOr<slot_offset_type> PageAllocatorState::write_checkpoint_slice(
       slot_range = slot_writer.append(
           slice_grant,
           PackedPageRefCountRefresh{
-              {
-                  .page_id = {this->page_ids_.make_page_id(physical_page, generation).int_value()},
-                  .ref_count = ref_count_obj->get_count(),
-              },
+              .page_id =
+                  {
+                      .id_val = this->page_ids_.make_page_id(physical_page, generation).int_value(),
+                  },
+              .ref_count = ref_count_obj->get_count(),
               .user_index = user_index,
           });
 

--- a/src/llfs/page_buffer.cpp
+++ b/src/llfs/page_buffer.cpp
@@ -13,6 +13,7 @@
 #include <llfs/page_layout.hpp>
 
 #include <batteries/math.hpp>
+#include <batteries/suppress.hpp>
 
 #include <boost/lockfree/policies.hpp>
 #include <boost/lockfree/queue.hpp>
@@ -122,7 +123,9 @@ void PageBuffer::operator delete(void* ptr)
       return;
     }
   }
+  BATT_SUPPRESS_IF_CLANG("-Wunevaluated-expression")
   delete[] reinterpret_cast<decltype(new Block[1])>(ptr);
+  BATT_UNSUPPRESS_IF_CLANG()
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/page_device_config.cpp
+++ b/src/llfs/page_device_config.cpp
@@ -9,6 +9,8 @@
 #include <llfs/page_device_config.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/config.hpp>
 #include <llfs/ioring_page_file_device.hpp>
 #include <llfs/page_layout.hpp>
@@ -97,3 +99,5 @@ StatusOr<std::unique_ptr<PageDevice>> recover_storage_object(
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/page_recycler_events.hpp
+++ b/src/llfs/page_recycler_events.hpp
@@ -71,7 +71,7 @@ std::ostream& operator<<(std::ostream& out, const PageToRecycle& t);
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
-struct PageRecyclerOptions;
+class PageRecyclerOptions;
 struct PackedPageToRecycle;
 struct PackedRecycleBatchCommit;
 struct PackedPageRecyclerInfo;

--- a/src/llfs/page_recycler_recovery_visitor.cpp
+++ b/src/llfs/page_recycler_recovery_visitor.cpp
@@ -69,7 +69,7 @@ std::vector<PageToRecycle> PageRecyclerRecoveryVisitor::recovered_pages() const
   // Remove all the deleted/prepared pages from the list.
   //
   to_recycle.erase(std::remove_if(to_recycle.begin(), to_recycle.end(),
-                                  [this](const PageToRecycle& p) {
+                                  [](const PageToRecycle& p) {
                                     return p.batch_slot;
                                   }),
                    to_recycle.end());

--- a/src/llfs/raw_block_file.hpp
+++ b/src/llfs/raw_block_file.hpp
@@ -88,10 +88,14 @@ class RawBlockFile
     return batt::StatusCode::kUnimplemented;
   }
 
+#ifndef LLFS_DISABLE_IO_URING
+  //
   virtual IoRing::File* get_io_ring_file()
   {
     return nullptr;
   }
+  //
+#endif  // LLFS_DISABLE_IO_URING
 
  protected:
   RawBlockFile() = default;

--- a/src/llfs/raw_block_file_impl.cpp
+++ b/src/llfs/raw_block_file_impl.cpp
@@ -9,6 +9,8 @@
 #include <llfs/raw_block_file_impl.hpp>
 //
 
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/filesystem.hpp>
 
 #include <batteries/async/io_result.hpp>
@@ -118,3 +120,5 @@ Status IoRingRawBlockFile::close()
 }
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING

--- a/src/llfs/raw_block_file_impl.hpp
+++ b/src/llfs/raw_block_file_impl.hpp
@@ -12,6 +12,11 @@
 #ifndef LLFS_RAW_BLOCK_FILE_IMPL_HPP
 #define LLFS_RAW_BLOCK_FILE_IMPL_HPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring_file.hpp>
 #include <llfs/optional.hpp>
 #include <llfs/raw_block_file.hpp>
@@ -55,5 +60,7 @@ class IoRingRawBlockFile : public RawBlockFile
 };
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_RAW_BLOCK_FILE_IMPL_HPP

--- a/src/llfs/ring_buffer.cpp
+++ b/src/llfs/ring_buffer.cpp
@@ -149,8 +149,12 @@ Status RingBuffer::sync()
 //
 Status RingBuffer::datasync()
 {
+#if LLFS_PLATFORM_IS_LINUX
   const int retval = fdatasync(this->fd_);
   return batt::status_from_retval(retval);
+#else
+  return this->sync();
+#endif
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/slot.hpp
+++ b/src/llfs/slot.hpp
@@ -29,10 +29,7 @@ using slot_size_type = u32;
 constexpr u64 kSlotDistanceUpperBound = (u64{1} << 63);
 constexpr u64 kMaxSlotDistance = kSlotDistanceUpperBound - 1;
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
+BATT_SUPPRESS_IF_GCC("-Wmaybe-uninitialized")
 
 // Returns true iff `first` is strictly less than `second`.
 //
@@ -95,9 +92,7 @@ struct SlotGreater {
   }
 };
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+BATT_UNSUPPRESS_IF_GCC()
 
 inline slot_offset_type slot_min(slot_offset_type first, slot_offset_type second)
 {

--- a/src/llfs/slot_interval_map.test.cpp
+++ b/src/llfs/slot_interval_map.test.cpp
@@ -36,7 +36,7 @@ TEST(SlotIntervalMapTest, RandomUpdates)
     std::array<llfs::slot_offset_type, kTestLogSize> expected_values;
     expected_values.fill(0);
 
-    std::default_random_engine rng{seed};
+    std::default_random_engine rng{(u32)seed};
 
     for (usize i = 0; i < kUpdateCount; ++i) {
       std::uniform_int_distribution<usize> pick_lower_bound{usize{0}, expected_values.size() - 1};

--- a/src/llfs/slot_read_lock.hpp
+++ b/src/llfs/slot_read_lock.hpp
@@ -13,13 +13,12 @@
 #include <llfs/pointers.hpp>
 #include <llfs/slot.hpp>
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#if __GNUC__ >= 9
-#pragma GCC diagnostic ignored "-Wdeprecated-copy"
-#endif  // __GNUC__ >= 9
-#endif  // __GNUC__
+#include <batteries/suppress.hpp>
+
+BATT_SUPPRESS_IF_GCC("-Wunused-parameter")
+BATT_SUPPRESS_IF_GCC("-Wdeprecated-copy")
+
+#include <batteries/hint.hpp>
 
 #include <batteries/hint.hpp>
 
@@ -201,8 +200,7 @@ class SlotReadLock
 
 }  // namespace llfs
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif  // __GNUC__
+BATT_UNSUPPRESS_IF_GCC()  // "-Wdeprecated-copy"
+BATT_UNSUPPRESS_IF_GCC()  // "-Wunused-parameter"
 
 #endif  // LLFS_SLOT_READ_LOCK_HPP

--- a/src/llfs/storage_context.hpp
+++ b/src/llfs/storage_context.hpp
@@ -10,6 +10,11 @@
 #ifndef LLFS_STORAGE_CONTEXT_HPP
 #define LLFS_STORAGE_CONTEXT_HPP
 
+#include <llfs/config.hpp>
+//
+
+#ifndef LLFS_DISABLE_IO_URING
+
 #include <llfs/ioring.hpp>
 #include <llfs/packed_config.hpp>
 #include <llfs/page_cache.hpp>
@@ -156,5 +161,7 @@ class StorageContext : public batt::RefCounted<StorageContext>
 };
 
 }  // namespace llfs
+
+#endif  // LLFS_DISABLE_IO_URING
 
 #endif  // LLFS_STORAGE_CONTEXT_HPP

--- a/src/llfs/storage_file.cpp
+++ b/src/llfs/storage_file.cpp
@@ -11,6 +11,8 @@
 
 #include <llfs/status_code.hpp>
 
+#include <batteries/math.hpp>
+
 namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/volume_runtime_options.hpp
+++ b/src/llfs/volume_runtime_options.hpp
@@ -11,6 +11,7 @@
 #define LLFS_VOLUME_RUNTIME_OPTIONS_HPP
 
 #include <llfs/ioring_log_driver_options.hpp>
+#include <llfs/slot_lock_manager.hpp>
 #include <llfs/volume_reader.hpp>
 
 #include <batteries/async/task_scheduler.hpp>


### PR DESCRIPTION
Also adds PackedBytes::clear().

List of changes:

- Turn on generation of `compile_commands.json` in CMakeLists.txt, to enable better code inspection (e.g., vscode, clang tooling)
- Remove many unnecessary captured variables in lambdas
- Tune warning suppressions to support Clang builds (coming in a future PR)
- Turn of compilation of liburing/io_uring when not on Linux
- Replace non-portable pragmas with `BATT_SUPPRESS_*`
- Fix various pedantic compilation issues: 
    - `[[maybe_unused]]` must come first in function declarations
    - designated initializers must be consistently/exclusively used in a statement