### PR TITLE
Llfs packable ref change

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class LlfsConan(ConanFile):
         "gtest/1.13.0",
         "boost/1.81.0",
         "glog/0.6.0",
-        "batteries/0.34.11@batteriescpp+batteries/stable",
+        "batteries/0.35.0@batteriescpp+batteries/stable",
         "cli11/2.3.2",
 
         # Version overrides (conflict resolutions)

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -46,13 +46,6 @@ const boost::uuids::uuid& Volume::get_trimmer_uuid() const
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-u64 Volume::calculate_grant_size(const PackableRef& payload) const
-{
-  return packed_sizeof_slot(payload);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
 u64 Volume::calculate_grant_size(const std::string_view& payload) const
 {
   // We must use `pack_as_raw` here so that when/if the payload is passed to a
@@ -434,20 +427,13 @@ StatusOr<batt::Grant> Volume::reserve(u64 size, batt::WaitForResource wait_for_l
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-StatusOr<SlotRange> Volume::append(const PackableRef& payload, batt::Grant& grant)
-{
-  return this->slot_writer_.append(grant, payload);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
 StatusOr<SlotRange> Volume::append(const std::string_view& payload, batt::Grant& grant)
 {
   // We must use `pack_as_raw` here so that when/if the payload is passed to a
   // slot visitor, it will not include a PackedBytes header; rather it should be
   // exactly the same bytes as `payload`.
   //
-  return this->append(PackableRef{pack_as_raw(payload)}, grant);
+  return this->append(pack_as_raw(payload), grant);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -46,17 +46,6 @@ const boost::uuids::uuid& Volume::get_trimmer_uuid() const
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-u64 Volume::calculate_grant_size(const std::string_view& payload) const
-{
-  // We must use `pack_as_raw` here so that when/if the payload is passed to a
-  // slot visitor, it will not include a PackedBytes header; rather it should be
-  // exactly the same bytes as `payload`.
-  //
-  return packed_sizeof_slot(pack_as_raw(payload));
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
 u64 Volume::calculate_grant_size(const AppendableJob& appendable) const
 {
   return (packed_sizeof_slot(prepare(appendable)) +
@@ -423,17 +412,6 @@ StatusOr<SlotReadLock> Volume::lock_slots(const SlotRange& slot_range, LogReadMo
 StatusOr<batt::Grant> Volume::reserve(u64 size, batt::WaitForResource wait_for_log_space)
 {
   return this->slot_writer_.reserve(size, wait_for_log_space);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-StatusOr<SlotRange> Volume::append(const std::string_view& payload, batt::Grant& grant)
-{
-  // We must use `pack_as_raw` here so that when/if the payload is passed to a
-  // slot visitor, it will not include a PackedBytes header; rather it should be
-  // exactly the same bytes as `payload`.
-  //
-  return this->append(pack_as_raw(payload), grant);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -97,10 +97,6 @@ class Volume
   template <typename T>
   u64 calculate_grant_size(const T& payload) const;
 
-  // Returns the number of bytes needed to append `payload`.
-  //
-  u64 calculate_grant_size(const std::string_view& payload) const;
-
   // Returns the number of bytes needed to append `prepare_job`.
   //
   u64 calculate_grant_size(const AppendableJob& appendable) const;
@@ -109,10 +105,6 @@ class Volume
   //
   template <typename T>
   StatusOr<SlotRange> append(const T& payload, batt::Grant& grant);
-
-  // Atomically append a new slot containing `payload` to the end of the root log.
-  //
-  StatusOr<SlotRange> append(const std::string_view& payload, batt::Grant& grant);
 
   // Create a new PageCacheJob for writing new pages via the WAL of this Volume.
   //

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -97,6 +97,10 @@ class Volume
   template <typename T>
   u64 calculate_grant_size(const T& payload) const;
 
+  // Returns the number of bytes needed to append `payload`.
+  //
+  u64 calculate_grant_size(const std::string_view& payload) const;
+
   // Returns the number of bytes needed to append `prepare_job`.
   //
   u64 calculate_grant_size(const AppendableJob& appendable) const;
@@ -105,6 +109,10 @@ class Volume
   //
   template <typename T>
   StatusOr<SlotRange> append(const T& payload, batt::Grant& grant);
+
+  // Atomically append a new slot containing `payload` to the end of the root log.
+  //
+  StatusOr<SlotRange> append(const std::string_view& payload, batt::Grant& grant);
 
   // Create a new PageCacheJob for writing new pages via the WAL of this Volume.
   //

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -93,7 +93,8 @@ class Volume
 
   // Returns the number of bytes needed to append `payload`.
   //
-  u64 calculate_grant_size(const PackableRef& payload) const;
+  template <typename T>
+  u64 calculate_grant_size(const T& payload) const;
 
   // Returns the number of bytes needed to append `payload`.
   //
@@ -105,7 +106,8 @@ class Volume
 
   // Atomically append a new slot containing `payload` to the end of the root log.
   //
-  StatusOr<SlotRange> append(const PackableRef& payload, batt::Grant& grant);
+  template <typename T>
+  StatusOr<SlotRange> append(const T& payload, batt::Grant& grant);
 
   // Atomically append a new slot containing `payload` to the end of the root log.
   //

--- a/src/llfs/volume.ipp
+++ b/src/llfs/volume.ipp
@@ -22,6 +22,18 @@ inline StatusOr<TypedVolumeReader<T>> Volume::typed_reader(const SlotRangeSpec& 
   return TypedVolumeReader<T>{std::move(*reader)};
 }
 
+template <typename T>
+u64 Volume::calculate_grant_size(const T& payload) const
+{
+  return packed_sizeof_slot(payload);
+}
+
+template <typename T>
+StatusOr<SlotRange> Volume::append(const T& payload, batt::Grant& grant)
+{
+  return this->slot_writer_.append(grant, payload);
+}
+
 }  // namespace llfs
 
 #endif  // LLFS_VOLUME_IPP

--- a/src/llfs/volume.ipp
+++ b/src/llfs/volume.ipp
@@ -31,7 +31,7 @@ u64 Volume::calculate_grant_size(const T& payload) const
 template <typename T>
 StatusOr<SlotRange> Volume::append(const T& payload, batt::Grant& grant)
 {
-  llfs::PackObjectAsRawData<T> packed_obj_as_raw{payload};
+  llfs::PackObjectAsRawData<const T&> packed_obj_as_raw{payload};
 
   return this->slot_writer_.append(grant, packed_obj_as_raw);
 }

--- a/src/llfs/volume.ipp
+++ b/src/llfs/volume.ipp
@@ -31,7 +31,9 @@ u64 Volume::calculate_grant_size(const T& payload) const
 template <typename T>
 StatusOr<SlotRange> Volume::append(const T& payload, batt::Grant& grant)
 {
-  return this->slot_writer_.append(grant, payload);
+  llfs::PackObjectAsRawData<T> packed_obj_as_raw{payload};
+
+  return this->slot_writer_.append(grant, packed_obj_as_raw);
 }
 
 }  // namespace llfs

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -352,13 +352,14 @@ TEST_F(VolumeTest, ReadWriteEvents)
     for (i32 key = 0; key < 10; key += 1) {
       UpsertEvent upsert{key, key * 3 + 1};
       auto upsert_event = llfs::pack_as_variant<TestVolumeEvent>(upsert);
+      llfs::PackObjectAsRawData<decltype(upsert_event)> bb{upsert_event};
 
       llfs::StatusOr<batt::Grant> grant = test_volume->reserve(
           test_volume->calculate_grant_size(upsert_event), batt::WaitForResource::kFalse);
 
       ASSERT_TRUE(grant.ok());
 
-      llfs::StatusOr<llfs::SlotRange> appended = test_volume->append(upsert_event, *grant);
+      llfs::StatusOr<llfs::SlotRange> appended = test_volume->append(bb, *grant);
 
       ASSERT_TRUE(appended.ok()) << appended.status();
 

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -352,14 +352,13 @@ TEST_F(VolumeTest, ReadWriteEvents)
     for (i32 key = 0; key < 10; key += 1) {
       UpsertEvent upsert{key, key * 3 + 1};
       auto upsert_event = llfs::pack_as_variant<TestVolumeEvent>(upsert);
-      llfs::PackObjectAsRawData<decltype(upsert_event)> bb{upsert_event};
 
       llfs::StatusOr<batt::Grant> grant = test_volume->reserve(
           test_volume->calculate_grant_size(upsert_event), batt::WaitForResource::kFalse);
 
       ASSERT_TRUE(grant.ok());
 
-      llfs::StatusOr<llfs::SlotRange> appended = test_volume->append(bb, *grant);
+      llfs::StatusOr<llfs::SlotRange> appended = test_volume->append(upsert_event, *grant);
 
       ASSERT_TRUE(appended.ok()) << appended.status();
 

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -352,14 +352,13 @@ TEST_F(VolumeTest, ReadWriteEvents)
     for (i32 key = 0; key < 10; key += 1) {
       UpsertEvent upsert{key, key * 3 + 1};
       auto upsert_event = llfs::pack_as_variant<TestVolumeEvent>(upsert);
-      auto packable_event = llfs::PackableRef{upsert_event};
 
       llfs::StatusOr<batt::Grant> grant = test_volume->reserve(
-          test_volume->calculate_grant_size(packable_event), batt::WaitForResource::kFalse);
+          test_volume->calculate_grant_size(upsert_event), batt::WaitForResource::kFalse);
 
       ASSERT_TRUE(grant.ok());
 
-      llfs::StatusOr<llfs::SlotRange> appended = test_volume->append(packable_event, *grant);
+      llfs::StatusOr<llfs::SlotRange> appended = test_volume->append(upsert_event, *grant);
 
       ASSERT_TRUE(appended.ok()) << appended.status();
 

--- a/src/llfs/volume_config.test.cpp
+++ b/src/llfs/volume_config.test.cpp
@@ -180,24 +180,24 @@ TEST_F(VolumeConfigTest, ConfigRestore)
 
     llfs::Volume& volume = **maybe_volume;
     llfs::StatusOr<batt::Grant> grant =
-        volume.reserve(volume.calculate_grant_size("alpha") +        //
-                           volume.calculate_grant_size("bravo") +    //
-                           volume.calculate_grant_size("charlie") +  //
-                           volume.calculate_grant_size("delta"),
+        volume.reserve(volume.calculate_grant_size(std::string_view("alpha")) +        //
+                           volume.calculate_grant_size(std::string_view("bravo")) +    //
+                           volume.calculate_grant_size(std::string_view("charlie")) +  //
+                           volume.calculate_grant_size(std::string_view("delta")),
                        batt::WaitForResource::kTrue);
 
     ASSERT_TRUE(grant.ok()) << BATT_INSPECT(grant.status());
 
-    alpha_slot = volume.append("alpha", *grant);
+    alpha_slot = volume.append(std::string_view("alpha"), *grant);
     ASSERT_TRUE(alpha_slot.ok()) << BATT_INSPECT(alpha_slot.status());
 
-    bravo_slot = volume.append("bravo", *grant);
+    bravo_slot = volume.append(std::string_view("bravo"), *grant);
     ASSERT_TRUE(bravo_slot.ok()) << BATT_INSPECT(bravo_slot.status());
 
-    charlie_slot = volume.append("charlie", *grant);
+    charlie_slot = volume.append(std::string_view("charlie"), *grant);
     ASSERT_TRUE(charlie_slot.ok()) << BATT_INSPECT(charlie_slot.status());
 
-    delta_slot = volume.append("delta", *grant);
+    delta_slot = volume.append(std::string_view("delta"), *grant);
     ASSERT_TRUE(delta_slot.ok()) << BATT_INSPECT(delta_slot.status());
 
     llfs::Status sync_status = volume


### PR DESCRIPTION
Please review LLFS changes which remove usage of PackableRef from VolumeTest's ReadWriteEvents flow. This change will allow passing of payload to Volume::append and Volume::calculate_grant_size without PackableRef wrapper.    

Fix #65 