### PR TITLE
Volume log data capture

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class LlfsConan(ConanFile):
         "gtest/1.13.0",
         "boost/1.81.0",
         "glog/0.6.0",
-        "batteries/0.36.0@batteriescpp+batteries/stable",
+        "batteries/0.36.4@batteriescpp+batteries/stable",
         "cli11/2.3.2",
 
         # Version overrides (conflict resolutions)
@@ -92,6 +92,6 @@ class LlfsConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.cxxflags = ["-std=c++17", "-D_GNU_SOURCE", "-D_BITS_UIO_EXT_H=1"]
+        self.cpp_info.cxxflags = ["-D_GNU_SOURCE", "-D_BITS_UIO_EXT_H=1"]
         self.cpp_info.system_libs = ["dl"]
         self.cpp_info.libs = ["llfs"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class LlfsConan(ConanFile):
         "gtest/1.13.0",
         "boost/1.81.0",
         "glog/0.6.0",
-        "batteries/0.35.2@batteriescpp+batteries/stable",
+        "batteries/0.36.0@batteriescpp+batteries/stable",
         "cli11/2.3.2",
 
         # Version overrides (conflict resolutions)

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class LlfsConan(ConanFile):
         "gtest/1.13.0",
         "boost/1.81.0",
         "glog/0.6.0",
-        "batteries/0.34.11@batteriescpp+batteries/stable",
+        "batteries/0.35.2@batteriescpp+batteries/stable",
         "cli11/2.3.2",
 
         # Version overrides (conflict resolutions)

--- a/src/llfs/api_types.hpp
+++ b/src/llfs/api_types.hpp
@@ -31,6 +31,10 @@ BATT_STRONG_TYPEDEF(bool, OkIfNotFound);
  */
 BATT_STRONG_TYPEDEF(bool, UseParallelCopy);
 
+/** \brief The number of bytes by which to delay trimming a Volume root log.
+ */
+BATT_STRONG_TYPEDEF(u64, TrimDelayByteCount);
+
 }  // namespace llfs
 
 #endif  // LLFS_API_TYPES_HPP

--- a/src/llfs/pack_as_raw.hpp
+++ b/src/llfs/pack_as_raw.hpp
@@ -91,7 +91,7 @@ inline PackObjectAsRawData<T> pack_object_as_raw(T&& object)
 template <typename T>
 inline usize packed_sizeof(const PackObjectAsRawData<T>& to_pack)
 {
-  return ::llfs::packed_sizeof(unwrap_ref(to_pack.object));
+  return packed_sizeof(unwrap_ref(to_pack.object));
 }
 
 template <typename T>

--- a/src/llfs/packable_ref.cpp
+++ b/src/llfs/packable_ref.cpp
@@ -11,4 +11,11 @@
 
 namespace llfs {
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+usize packed_sizeof(const PackableRef& p)
+{
+  return p.packed_size();
+}
+
 }  // namespace llfs

--- a/src/llfs/packable_ref.hpp
+++ b/src/llfs/packable_ref.hpp
@@ -150,10 +150,7 @@ class PackableRef
   const void* ptr_;
 };
 
-inline usize packed_sizeof(const PackableRef& p)
-{
-  return p.packed_size();
-}
+usize packed_sizeof(const PackableRef& p);
 
 inline PackedRawData* pack_object(const PackableRef& p, DataPacker* dst)
 {

--- a/src/llfs/page_allocator.cpp
+++ b/src/llfs/page_allocator.cpp
@@ -13,6 +13,7 @@
 #include <llfs/data_reader.hpp>
 #include <llfs/metrics.hpp>
 #include <llfs/slot_reader.hpp>
+#include <llfs/system_config.hpp>
 
 #include <llfs/logging.hpp>
 
@@ -50,7 +51,7 @@ u64 PageAllocator::calculate_log_size(u64 physical_page_count, u64 max_attachmen
   const u64 rough_size = (max_checkpoint_size + max_transaction_size + kCheckpointGrantSize) * 4 +
                          kCheckpointGrantSize - 1;
 
-  return rough_size - rough_size % kCheckpointGrantSize;
+  return round_up_to_page_size_multiple(rough_size - rough_size % kCheckpointGrantSize);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/page_device.hpp
+++ b/src/llfs/page_device.hpp
@@ -33,8 +33,8 @@ class PageDevice
   using WriteResult = Status;
   using ReadResult = StatusOr<std::shared_ptr<const PageBuffer>>;
 
-  using WriteHandler = std::function<void(WriteResult)>;
-  using ReadHandler = std::function<void(ReadResult)>;
+  using WriteHandler = std::function<void(PageDevice::WriteResult)>;
+  using ReadHandler = std::function<void(PageDevice::ReadResult)>;
 
   PageDevice(const PageDevice&) = delete;
   PageDevice& operator=(const PageDevice&) = delete;
@@ -70,21 +70,22 @@ class PageDevice
   //
   virtual StatusOr<std::shared_ptr<PageBuffer>> prepare(PageId page_id) = 0;
 
-  virtual void write(std::shared_ptr<const PageBuffer>&& page_buffer, WriteHandler&& handler) = 0;
+  virtual void write(std::shared_ptr<const PageBuffer>&& page_buffer,
+                     PageDevice::WriteHandler&& handler) = 0;
 
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   // Read phase
   //
-  virtual void read(PageId id, ReadHandler&& handler) = 0;
+  virtual void read(PageId id, PageDevice::ReadHandler&& handler) = 0;
 
   // Convenience; shortcut for Task::await(...)
   //
-  ReadResult await_read(PageId id);
+  PageDevice::ReadResult await_read(PageId id);
 
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   // Delete phase
   //
-  virtual void drop(PageId id, WriteHandler&& handler) = 0;
+  virtual void drop(PageId id, PageDevice::WriteHandler&& handler) = 0;
 
  protected:
   PageDevice() = default;

--- a/src/llfs/page_recycler.cpp
+++ b/src/llfs/page_recycler.cpp
@@ -16,6 +16,7 @@ BATT_SUPPRESS_IF_GCC("-Wmaybe-uninitialized")
 #include <llfs/metrics.hpp>
 #include <llfs/page_cache_job.hpp>
 #include <llfs/page_recycler_recovery_visitor.hpp>
+#include <llfs/system_config.hpp>
 
 #include <batteries/async/backoff.hpp>
 #include <batteries/finally.hpp>
@@ -74,11 +75,12 @@ StatusOr<SlotRange> refresh_recycler_info_slot(TypedSlotWriter<PageRecycleEvent>
 {
   static const PackedPageRecyclerInfo info = {};
 
-  return options.total_page_grant_size() *
-             (1 + max_buffered_page_count.value_or(
-                      PageRecycler::default_max_buffered_page_count(options))) +
-         options.recycle_task_target() +
-         packed_sizeof_slot(info) * (options.info_refresh_rate() + 1) + 1 * kKiB;
+  return round_up_to_page_size_multiple(
+      options.total_page_grant_size() *
+          (1 + max_buffered_page_count.value_or(
+                   PageRecycler::default_max_buffered_page_count(options))) +
+      options.recycle_task_target() + packed_sizeof_slot(info) * (options.info_refresh_rate() + 1) +
+      1 * kKiB);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/page_recycler.test.cpp
+++ b/src/llfs/page_recycler.test.cpp
@@ -442,7 +442,7 @@ void PageRecyclerTest::run_crash_recovery_test()
   const u64 log_size = PageRecycler::calculate_log_size(options);
   LLFS_VLOG(1) << BATT_INSPECT(log_size);
 
-  EXPECT_EQ(PageRecycler::calculate_max_buffered_page_count(options, log_size),
+  EXPECT_GE(PageRecycler::calculate_max_buffered_page_count(options, log_size),
             PageRecycler::default_max_buffered_page_count(options));
 
   for (u64 seed = 0; seed < 10000; ++seed) {

--- a/src/llfs/simulated_log_device_reader_impl.hpp
+++ b/src/llfs/simulated_log_device_reader_impl.hpp
@@ -69,11 +69,6 @@ class SimulatedLogDevice::Impl::ReaderImpl : public LogDevice::Reader
   // the slot has been partially trimmed.
   //
   usize data_size_ = 0;
-
-  // Only valid between calls to data() and consume(); the chunk currently being read by the user of
-  // this reader.
-  //
-  std::shared_ptr<Impl::CommitChunk> chunk_;
 };
 
 }  //namespace llfs

--- a/src/llfs/slot.hpp
+++ b/src/llfs/slot.hpp
@@ -262,6 +262,35 @@ inline std::ostream& operator<<(std::ostream& out, const SlotWithPayload<T>& t)
 
 constexpr usize kMaxSlotHeaderSize = kMaxVarInt32Size;
 
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+
+/** \brief Returns the input SlotRange by const ref.
+ */
+inline const SlotRange& get_slot_range(const SlotRange& s) noexcept
+{
+  return s;
+}
+
+/** \brief Returns the slot range of the input.
+ */
+template <typename T>
+inline const SlotRange& get_slot_range(const SlotWithPayload<T>& s) noexcept
+{
+  return s.slot_range;
+}
+
+/** \brief Defines the partial order over all SlotRange values such that for any pair of SlotRanges
+ * (a, b), a < b iff a.upper_bound <= b.lower_bound.
+ */
+struct SlotRangeOrder {
+  template <typename First, typename Second>
+  bool operator()(const First& first, const Second& second) const
+  {
+    return slot_less_or_equal(get_slot_range(first).upper_bound,
+                              get_slot_range(second).lower_bound);
+  }
+};
+
 }  // namespace llfs
 
 #endif  // LLFS_SLOT_HPP

--- a/src/llfs/storage_simulation.cpp
+++ b/src/llfs/storage_simulation.cpp
@@ -342,6 +342,7 @@ StatusOr<std::unique_ptr<Volume>> StorageSimulation::get_volume(
       .uuid = None,
       .max_refs_per_page = MaxRefsPerPage{0},
       .trim_lock_update_interval = TrimLockUpdateInterval{512 /*bytes*/},
+      .trim_delay_byte_count = TrimDelayByteCount{0},
   });
 
   //----- --- -- -  -  -   -

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -145,6 +145,10 @@ class Volume
   //
   Status await_trim(slot_offset_type slot_lower_bound);
 
+  /** \brief Returns the current root log trim position.
+   */
+  slot_offset_type get_trim_pos() const noexcept;
+
   // Returns the PageCache associated with this Volume.
   //
   PageCache& cache() const;
@@ -197,6 +201,13 @@ class Volume
   // Returns diagnostic metrics for this Volume's PageRecycler.
   //
   const PageRecycler::Metrics& page_recycler_metrics() const;
+
+  /** \brief Returns the root log data corresponding to the given slot read lock.
+   *
+   * The returned buffer is valid only as long as the lock is held.
+   */
+  StatusOr<ConstBuffer> get_root_log_data(const SlotReadLock& read_lock,
+                                          Optional<SlotRange> slot_range = None) const;
 
   LogDevice& root_log() const noexcept
   {

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -204,11 +204,17 @@ class Volume
 
   /** \brief Returns the root log data corresponding to the given slot read lock.
    *
-   * The returned buffer is valid only as long as the lock is held.
+   * The returned buffer is valid only as long as the lock is held.  The requested/returned slot
+   * range may be up to "trim_delay_byte_count" bytes before the lower-bound of the passed
+   * read_lock.
+   *
+   * \param slot_range The slot offsets to return; if None, defaults to `read_lock.slot_range()`
    */
   StatusOr<ConstBuffer> get_root_log_data(const SlotReadLock& read_lock,
                                           Optional<SlotRange> slot_range = None) const;
 
+  /** \brief Returns a reference to the root log's LogDevice object.
+   */
   LogDevice& root_log() const noexcept
   {
     return *(this->root_log_);

--- a/src/llfs/volume.ipp
+++ b/src/llfs/volume.ipp
@@ -10,8 +10,13 @@
 #ifndef LLFS_VOLUME_IPP
 #define LLFS_VOLUME_IPP
 
+#include <llfs/buffered_log_data_reader.hpp>
+#include <llfs/volume_slot_demuxer.hpp>
+
 namespace llfs {
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 template <typename T>
 inline StatusOr<TypedVolumeReader<T>> Volume::typed_reader(const SlotRangeSpec& slot_range,
                                                            LogReadMode mode, batt::StaticType<T>)

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -18,6 +18,7 @@
 #include <llfs/memory_log_device.hpp>
 #include <llfs/memory_page_cache.hpp>
 #include <llfs/opaque_page_view.hpp>
+#include <llfs/packable_ref.hpp>
 #include <llfs/page_graph_node.hpp>
 #include <llfs/raw_volume_log_data_parser.hpp>
 #include <llfs/storage_simulation.hpp>

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -137,6 +137,7 @@ class VolumeTest : public ::testing::Test
                 .uuid = llfs::None,
                 .max_refs_per_page = max_refs_per_page,
                 .trim_lock_update_interval = llfs::TrimLockUpdateInterval{0u},
+                .trim_delay_byte_count = llfs::TrimDelayByteCount{0},
             },
             this->page_cache,
             /*root_log=*/&root_log,

--- a/src/llfs/volume_config.cpp
+++ b/src/llfs/volume_config.cpp
@@ -66,6 +66,7 @@ Status configure_storage_object(StorageFileBuilder::Transaction& txn,
   p_config->slot_1.slot_i = 1;
   p_config->slot_1.n_slots = 2;
   p_config->trim_lock_update_interval_bytes = options.base.trim_lock_update_interval;
+  p_config->trim_delay_byte_count = options.base.trim_delay_byte_count;
 
   if (!txn.packer().pack_string_to(&p_config->name, options.base.name)) {
     return ::batt::StatusCode::kResourceExhausted;
@@ -104,6 +105,7 @@ StatusOr<std::unique_ptr<Volume>> recover_storage_object(
               .max_refs_per_page = MaxRefsPerPage{p_volume_config->max_refs_per_page},
               .trim_lock_update_interval =
                   TrimLockUpdateInterval{p_volume_config->trim_lock_update_interval_bytes},
+              .trim_delay_byte_count = TrimDelayByteCount{p_volume_config->trim_delay_byte_count},
           },
       .cache = *page_cache,
       .root_log_factory = root_log_factory->get(),

--- a/src/llfs/volume_config.hpp
+++ b/src/llfs/volume_config.hpp
@@ -95,13 +95,17 @@ struct PackedVolumeConfig : PackedConfigSlotHeader {
   //
   little_u64 trim_lock_update_interval_bytes;
 
+  // The number of bytes by which to delay log trimming.
+  //
+  little_u64 trim_delay_byte_count;
+
   // Human-readable volume name - UTF-8 encoding
   //
   PackedBytes name;
 
   // Reserved for future use.
   //
-  u8 pad1_[44];
+  u8 pad1_[36];
 };
 
 BATT_STATIC_ASSERT_EQ(sizeof(PackedVolumeConfig), PackedVolumeConfig::kSize);

--- a/src/llfs/volume_config.test.cpp
+++ b/src/llfs/volume_config.test.cpp
@@ -127,6 +127,7 @@ TEST_F(VolumeConfigTest, ConfigRestore)
                         .uuid = llfs::None,
                         .max_refs_per_page = llfs::MaxRefsPerPage{1},
                         .trim_lock_update_interval = llfs::TrimLockUpdateInterval{4 * kKiB},
+                        .trim_delay_byte_count = llfs::TrimDelayByteCount{0},
                     },
                 .root_log =
                     llfs::LogDeviceConfigOptions{

--- a/src/llfs/volume_options.hpp
+++ b/src/llfs/volume_options.hpp
@@ -36,6 +36,8 @@ struct VolumeOptions {
   MaxRefsPerPage max_refs_per_page;
 
   TrimLockUpdateInterval trim_lock_update_interval;
+
+  TrimDelayByteCount trim_delay_byte_count;
 };
 
 }  // namespace llfs

--- a/src/llfs/volume_reader.cpp
+++ b/src/llfs/volume_reader.cpp
@@ -97,7 +97,6 @@ SlotRange VolumeReader::slot_range() const
 //
 SlotReadLock VolumeReader::clone_lock() const
 {
-  BATT_UNTESTED_LINE();
   return this->impl_->read_lock_.clone();
 }
 

--- a/src/llfs/volume_trimmer.test.cpp
+++ b/src/llfs/volume_trimmer.test.cpp
@@ -82,6 +82,8 @@ class VolumeTrimmerTest : public ::testing::Test
     this->job_grant_size = 0;
     this->leaked_job_grant_size = 0;
     this->verified_client_slot = 0;
+    this->trim_delay_byte_count = 0;
+    this->last_recovered_trim_pos = 0;
     this->initialize_log();
   }
 
@@ -186,6 +188,12 @@ class VolumeTrimmerTest : public ::testing::Test
     }
     this->job_grant = batt::None;
     this->fake_slot_writer.emplace(*this->fake_log);
+
+    // Set `last_recovered_trim_pos` so we don't think that trim delay is failing to arrest log
+    // trimming immediately after (re-)opening the log.
+    //
+    this->last_recovered_trim_pos =
+        this->fake_log->slot_range(llfs::LogReadMode::kDurable).lower_bound;
   }
 
   /** \brief Create a VolumeTrimmer for testing.
@@ -213,10 +221,12 @@ class VolumeTrimmerTest : public ::testing::Test
                  << BATT_INSPECT(this->recovery_visitor->get_refresh_info())
                  << BATT_INSPECT(this->recovery_visitor->get_trim_event_info())
                  << BATT_INSPECT_RANGE(this->recovery_visitor->get_pending_jobs())
-                 << BATT_INSPECT(this->recovery_visitor->get_trimmer_grant_size());
+                 << BATT_INSPECT(this->recovery_visitor->get_trimmer_grant_size())
+                 << BATT_INSPECT(this->trim_delay_byte_count);
 
     this->trimmer = std::make_unique<llfs::VolumeTrimmer>(
-        this->volume_ids.trimmer_uuid, *this->trim_control,
+        this->volume_ids.trimmer_uuid, "TestTrimmer", *this->trim_control,
+        llfs::TrimDelayByteCount{this->trim_delay_byte_count},
         this->fake_log->new_reader(/*slot_lower_bound=*/batt::None,
                                    llfs::LogReadMode::kSpeculative),
         *this->fake_slot_writer,
@@ -549,9 +559,77 @@ class VolumeTrimmerTest : public ::testing::Test
     }
   }
 
+  /** \brief Checks all invariants.
+   */
+  void check_invariants()
+  {
+    // Check to make sure that not too much of the log was trimmed.
+    //
+    {
+      BATT_CHECK(this->trim_control);
+      const llfs::slot_offset_type least_locked_slot = this->trim_control->get_lower_bound();
+
+      BATT_CHECK_NOT_NULLPTR(this->fake_log);
+      const llfs::slot_offset_type trim_pos =
+          this->fake_log->slot_range(llfs::LogReadMode::kDurable).lower_bound;
+
+      if (least_locked_slot >= this->last_recovered_trim_pos + this->trim_delay_byte_count) {
+        ASSERT_GE((i64)least_locked_slot - (i64)trim_pos, (i64)this->trim_delay_byte_count)
+            << BATT_INSPECT(this->trim_delay_byte_count) << BATT_INSPECT(least_locked_slot)
+            << BATT_INSPECT(trim_pos) << BATT_INSPECT(this->last_recovered_trim_pos);
+      } else {
+        ASSERT_EQ(trim_pos, this->last_recovered_trim_pos)
+            << BATT_INSPECT(least_locked_slot) << BATT_INSPECT(this->trim_delay_byte_count);
+      }
+    }
+  }
+
+  /** \brief Forces the trimmer task to shut down; usually because we have failed an ASSERT.
+   */
+  void force_shut_down()
+  {
+    // Only need to do something if the trimmer_task exists.
+    //
+    if (!this->trimmer_task) {
+      return;
+    }
+
+    // Halt everything that might be blocking the trimmer_task.
+    //
+    if (this->trimmer) {
+      this->trimmer->halt();
+    }
+    if (this->trim_control) {
+      this->trim_control->halt();
+    }
+    if (this->fake_log) {
+      this->fake_log->close().IgnoreError();
+    }
+
+    // Run tasks until there are no more.
+    //
+    for (;;) {
+      batt::UniqueHandler<> action = this->task_context.pop_ready_handler([this](usize /*n*/) {
+        return 0;
+      });
+      if (!action) {
+        break;
+      }
+      action();
+    }
+
+    // The trimmer_task should now be joined.
+    //
+    BATT_CHECK_EQ(this->trimmer_task->try_join(), batt::Task::IsDone{true});
+  }
+
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   std::default_random_engine rng{1234567};
+
+  u64 trim_delay_byte_count = 0;
+
+  llfs::slot_offset_type last_recovered_trim_pos = 0;
 
   std::array<i64, kNumPages> page_ref_count;
 
@@ -600,8 +678,6 @@ class VolumeTrimmerTest : public ::testing::Test
 };
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
-// seeds to investigate:
-// - 1:  seed_i == 461660
 //
 TEST_F(VolumeTrimmerTest, RandomizedTest)
 {
@@ -611,6 +687,12 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
   const usize kInitialSeed = 0;
   usize crash_count = 0;
 
+  // Make sure there are no running tasks when we return.
+  //
+  auto on_scope_exit = batt::finally([&] {
+    this->force_shut_down();
+  });
+
   for (usize seed_i = kInitialSeed; seed_i < kInitialSeed + kNumSeeds; seed_i += 1) {
     LLFS_LOG_INFO_EVERY_N(kLogEveryN) << "Starting new test run with empty log;"
                                       << BATT_INSPECT(seed_i) << BATT_INSPECT(crash_count);
@@ -618,6 +700,11 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
     this->rng.seed(seed_i * 741461423ull);
 
     this->reset_state();
+
+    // Pick a trim delay setting for this test run.
+    //
+    this->trim_delay_byte_count = this->pick_usize(0, 16) * 64;
+
     this->open_fake_log();
     this->initialize_trimmer();
 
@@ -629,6 +716,8 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
     for (int step_i = 0; !this->fake_log_has_failed(); ++step_i) {
       LLFS_VLOG(1) << "Step " << step_i;
 
+      ASSERT_NO_FATAL_FAILURE(this->check_invariants());
+
       // Let the VolumeTrimmer task run.
       //
       if (this->pick_branch()) {
@@ -638,6 +727,7 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
         });
         if (action) {
           ASSERT_NO_FATAL_FAILURE(action());
+          ASSERT_NO_FATAL_FAILURE(this->check_invariants());
         }
       }
 
@@ -645,6 +735,7 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
       //
       if (this->pick_branch()) {
         ASSERT_NO_FATAL_FAILURE(this->trim_log());
+        ASSERT_NO_FATAL_FAILURE(this->check_invariants());
       }
 
       // Write opaque user data slot, if there is enough log space.
@@ -652,26 +743,37 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
       if (this->fake_slot_writer->pool_size() > kMaxOpaqueDataSize + kMaxSlotOverhead &&
           this->pick_branch()) {
         ASSERT_NO_FATAL_FAILURE(this->append_opaque_data_slot()) << BATT_INSPECT(seed_i);
+        ASSERT_NO_FATAL_FAILURE(this->check_invariants());
       }
 
       // Write PrepareJob slot.
       //
       if (this->pick_branch()) {
         ASSERT_NO_FATAL_FAILURE(this->prepare_one_job());
+        ASSERT_NO_FATAL_FAILURE(this->check_invariants());
       }
 
       // Write CommitJob slot, if there is a pending job.
       //
       if (!this->pending_jobs.empty() && this->pick_branch()) {
         ASSERT_NO_FATAL_FAILURE(this->commit_one_job()) << BATT_INSPECT(seed_i);
+        ASSERT_NO_FATAL_FAILURE(this->check_invariants());
       }
 
       // Simulate a crash/recovery (rate=1%)
       //
       if (this->pick_usize(1, 100) <= 1) {
-        LLFS_VLOG(1) << "Simulating crash/recovery...";
+        LLFS_VLOG(1) << "Simulating crash/recovery..."
+                     << BATT_INSPECT(this->last_recovered_trim_pos)
+                     << BATT_INSPECT(this->fake_log->slot_range(llfs::LogReadMode::kDurable))
+                     << BATT_INSPECT(this->trim_control->get_lower_bound());
+
         ASSERT_NO_FATAL_FAILURE(this->shutdown_trimmer()) << BATT_INSPECT(seed_i);
+        ASSERT_NO_FATAL_FAILURE(this->check_invariants());
+
         ASSERT_NO_FATAL_FAILURE(this->initialize_trimmer());
+        ASSERT_NO_FATAL_FAILURE(this->check_invariants());
+
         crash_count += 1;
       }
     }
@@ -679,6 +781,7 @@ TEST_F(VolumeTrimmerTest, RandomizedTest)
     LLFS_VLOG(1) << "Exited loop; joining trimmer task";
 
     ASSERT_NO_FATAL_FAILURE(this->shutdown_trimmer()) << BATT_INSPECT(seed_i);
+    ASSERT_NO_FATAL_FAILURE(this->check_invariants());
   }
 }
 


### PR DESCRIPTION
The log data capture interface is `Volume::get_root_log_data`, declared and documented in src/llfs/volume.hpp and implemented in src/llfs/volume.cpp.

The Volume trim delay feature is controlled by the `VolumeOptions::trim_delay_byte_count` property, defined in src/llfs/volume_options.hpp.  It is implemented in `VolumeTrimmer::await_trim_target`, declared in src/llfs/volume_trimmer.hpp and defined in src/llfs/volume_trimmer.cpp.

Testing for log data capture is implemented in two parts: 

1. Adding pass in `VolumeSimTest::verify_post_recovery_expectations` (src/llfs/volume.test.cpp), which accomplishes the same thing as the normal VolumeReader-based event scanning that was already there, but works by first capturing the log data and then using an `llfs::RawVolumeLogDataParser` to parse the log.  **This is a good place to start to see a typical use case for capturing and parsing log data** (src/llfs/volume.test.cpp:1805 and following)
2. Adding a number of edge cases that test the various code paths inside `Volume::get_root_log_data`, particularly error cases.  The specific cases (test plan) is outlined at src/llfs/volume.test.cpp:712; the test cases are implemented below this line.

I also discovered an unimplemented test plan in volume.test.cpp, relating to the slot lock manager trim control mechanism and VolumeReader instances.  I took the opportunity to implement them, as VolumeTest.TrimControl_LastVolumeReaderCausesTrim (line 659) and VolumeTest.TrimControl_VolumeReaderCloneLock (line 602).

Please do read the issue descriptions, as they document the rest of the changes (particularly the changes to the simulated log device and bug fixes in sim tests).

Fixes #68 
Fixes #67 
Fixes #64 
