### PR TITLE
updated PackedArray's memset to use -this- ptr

### DIFF
--- a/src/llfs/packed_array.hpp
+++ b/src/llfs/packed_array.hpp
@@ -46,7 +46,7 @@ struct PackedArray {
   template <typename I>
   void initialize(I count_arg)
   {
-    std::memset(&(this->item_count), 0, sizeof(PackedArray));
+    std::memset(this, 0, sizeof(PackedArray));
     this->item_count = count_arg;
 
     BATT_CHECK_EQ(count_arg, this->item_count.value());


### PR DESCRIPTION
This is to fix memset to use 'this' pointer instead of the base address of the first data member. 

Fix #103 