### PR TITLE
Fix import bug: missing script/batt.py when installing llfs in downstream package.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.files import copy
 
-import os, sys, platform
+import os, sys, platform, traceback
 
 VERBOSE = os.getenv('VERBOSE') and True or False
 
@@ -38,14 +38,22 @@ class LlfsConan(ConanFile):
 
     #+++++++++++-+-+--+----- --- -- -  -  -   -
     def _append_script_dir(self):
-        script_dir1 = os.path.join(os.path.dirname(__file__), 'script')
-        sys.path.append(script_dir1)
-
         try:
-            script_dir2 = os.path.join(os.path.split(self.source_folder)[0], 'script')
-            sys.path.append(script_dir2)
-        except:
-            pass
+            print(f'BEFORE modifying sys.path; cwd={os.getcwd()}, sys.path={sys.path}, source_folder={self.source_folder}, __file__={__file__}, stack=')
+            traceback.print_stack()
+        
+            script_dir1 = os.path.join(os.path.dirname(__file__), 'script')
+            sys.path.append(script_dir1)
+
+            try:
+                script_dir2 = os.path.join(os.path.split(self.source_folder)[0], 'script')
+                sys.path.append(script_dir2)
+            except:
+                pass
+            
+        finally:
+            print(f'AFTER modifying sys.path; cwd={os.getcwd()}, sys.path={sys.path}')
+            
     #+++++++++++-+-+--+----- --- -- -  -  -   -
 
     def set_version(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.files import copy
 
-import os, sys, platform, traceback
+import os, sys, platform
 
 
 #==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,9 +38,17 @@ class LlfsConan(ConanFile):
 
     #+++++++++++-+-+--+----- --- -- -  -  -   -
     def _append_script_dir(self):
+        newline = "\n      "
         try:
-            print(f'BEFORE modifying sys.path; cwd={os.getcwd()}, sys.path={sys.path}, source_folder={self.source_folder}, __file__={__file__}, stack=')
-            #traceback.print_stack()
+            print(
+                f'BEFORE modifying sys.path:' +
+                f'\n  cwd={os.getcwd()}' +
+                f'\n  sys.path={newline + newline.join(sys.path)}' +
+                f'\n  source_folder={self.source_folder}' +
+                f'\n  __file__={__file__}' +
+                f'\n  stack=', file=sys.stderr
+            )
+            traceback.print_stack(file=sys.stderr)
         
             script_dir1 = os.path.join(os.path.dirname(__file__), 'script')
             sys.path.append(script_dir1)
@@ -52,7 +60,12 @@ class LlfsConan(ConanFile):
                 pass
             
         finally:
-            print(f'AFTER modifying sys.path; cwd={os.getcwd()}, sys.path={sys.path}')
+            print(
+                f'\nAFTER modifying sys.path:' +
+                f'\n  cwd={os.getcwd()}' +
+                f'\n  sys.path={newline + newline.join(sys.path)}', file=sys.stderr
+            )
+            pass
             
     #+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,7 @@ class LlfsConan(ConanFile):
     def _append_script_dir(self):
         try:
             print(f'BEFORE modifying sys.path; cwd={os.getcwd()}, sys.path={sys.path}, source_folder={self.source_folder}, __file__={__file__}, stack=')
-            traceback.print_stack()
+            #traceback.print_stack()
         
             script_dir1 = os.path.join(os.path.dirname(__file__), 'script')
             sys.path.append(script_dir1)


### PR DESCRIPTION
Turns out that we should have been using `exports`, instead of `exports_sources` all along for helper python files!