### PR TITLE
Fix for IoRing shutdown hang bug.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ default:
     - "test -d /local/gitlab-runner-local-cache || { echo \"FATAL: no local docker cache volume mapped\"; false; }"
     - export XDG_CACHE_HOME=/local/gitlab-runner-local-cache/.cache
     - export CONAN_USER_HOME=/local/gitlab-runner-local-cache
-    - export CONAN_HOME=/local/gitlab-runner-local-cache/.conan2
+    - export CONAN_HOME=/local/gitlab-runner-local-cache/.conan_2.0.16
     - /setup-conan.sh
     - echo "CI_DEPLOY_USER=${CI_DEPLOY_USER}"
     - echo "CI_DEPLOY_PASSWORD=${CI_DEPLOY_PASSWORD}"

--- a/src/llfs/ioring_impl.cpp
+++ b/src/llfs/ioring_impl.cpp
@@ -454,10 +454,7 @@ void IoRingImpl::invoke_handler(CompletionHandler** handler) noexcept
 {
   auto on_scope_exit = batt::finally([handler, this] {
     *handler = nullptr;
-    const isize prior_count = this->work_count_.fetch_sub(1);
-    if (prior_count == 1) {
-      this->wake_all();
-    }
+    this->on_work_finished();
   });
 
   BATT_CHECK((*handler)->result);

--- a/src/llfs/ioring_impl.hpp
+++ b/src/llfs/ioring_impl.hpp
@@ -183,6 +183,17 @@ class IoRingImpl
    */
   void invoke_handler(CompletionHandler** handler) noexcept;
 
+  /** \brief Wakes all threads inside a call to this->run().
+   *
+   * There are two blocking mechanisms which this function needs to address:
+   *
+   *   1. eventfd_read(), used to block waiting for the io_uring to signal an event
+   *      (one thread at a time)
+   *   2. this->state_change_.wait(), a condition variable wait used by all threads
+   *      _not_ waiting in eventfd_read(), to receive notification that they can proceed
+   */
+  void wake_all() noexcept;
+
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   // Protects access to the io_uring context and associated data (registered_fds_, free_fds_,


### PR DESCRIPTION
Fixes #143 

Changed the EnqueueManyHandlers test to run repeatedly in a loop 5000 times.  In interactive testing, this triggers the bug about 80% of the time, so I think its a good compromise between catching regressions and keeping the tests fast.

Recommend starting with the comment in the newly added `IoRingImpl::wake_all()` function.  