### PR TITLE
Test param tuning (LruClockTest)

### DIFF
--- a/src/llfs/lru_clock.test.cpp
+++ b/src/llfs/lru_clock.test.cpp
@@ -94,7 +94,7 @@ void run_sync_update_test(const usize kNumFastThreads)
   std::thread slow_thread{[&slow_thread_values] {
     for (usize i = 0; i < kSlowThreadReads; ++i) {
       std::this_thread::sleep_for(
-          std::chrono::microseconds(llfs::LRUClock::kMaxSyncDelayUsec * 10));
+          std::chrono::microseconds(llfs::LRUClock::kMaxSyncDelayUsec * 40));
       slow_thread_values[i] = llfs::LRUClock::read_local();
     }
   }};
@@ -144,7 +144,7 @@ void run_sync_update_test(const usize kNumFastThreads)
         << BATT_INSPECT(max_count) << BATT_INSPECT_RANGE(slow_thread_values);
   }
 
-  EXPECT_GT(slow_thread_values.back(), kUpdatesPerThread / 2);
+  EXPECT_GT(slow_thread_values.back(), kUpdatesPerThread / 10);
 }
 
 TEST(LruClockTest, SyncUpdate1)

--- a/src/llfs/lru_clock.test.cpp
+++ b/src/llfs/lru_clock.test.cpp
@@ -141,7 +141,7 @@ void run_sync_update_test(const usize kNumFastThreads)
     EXPECT_GT(slow_thread_values[i] - slow_thread_values[i - 1], 50)
         << BATT_INSPECT(i) << BATT_INSPECT(slow_thread_values[i])
         << BATT_INSPECT(slow_thread_values[i - 1]) << BATT_INSPECT(max_synced_count)
-        << BATT_INSPECT(max_count);
+        << BATT_INSPECT(max_count) << BATT_INSPECT_RANGE(slow_thread_values);
   }
 
   EXPECT_GT(slow_thread_values.back(), kUpdatesPerThread / 2);


### PR DESCRIPTION
Widens some tolerances to accommodate more variability in multi-threaded event timing.