### PR TITLE
Add Volume atomic multi-slot appends.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,11 +10,9 @@ AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLambdasOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowAllConstructorInitializersOnNextLine: false
 BreakBeforeBraces: Custom
 DerivePointerAlignment: false
 FixNamespaceComments: true
-IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth: 2
 PointerAlignment: Left

--- a/conanfile.py
+++ b/conanfile.py
@@ -69,7 +69,7 @@ class LlfsConan(ConanFile):
 
 
     def requirements(self):
-        self.requires("batteries/0.52.1", **VISIBLE)
+        self.requires("batteries/0.52.2", **VISIBLE)
         self.requires("boost/1.83.0", **VISIBLE)
         self.requires("cli11/2.3.2", **VISIBLE)
         self.requires("glog/0.6.0", **VISIBLE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -69,7 +69,7 @@ class LlfsConan(ConanFile):
 
 
     def requirements(self):
-        self.requires("batteries/0.52.2", **VISIBLE)
+        self.requires("batteries/0.52.4", **VISIBLE)
         self.requires("boost/1.83.0", **VISIBLE)
         self.requires("cli11/2.3.2", **VISIBLE)
         self.requires("glog/0.6.0", **VISIBLE)

--- a/src/llfs/basic_log_storage_driver.hpp
+++ b/src/llfs/basic_log_storage_driver.hpp
@@ -43,17 +43,17 @@ class BasicLogStorageDriver
   //
   Status set_trim_pos(slot_offset_type trim_pos)
   {
-    return impl_.set_trim_pos(trim_pos);
+    return this->impl_.set_trim_pos(trim_pos);
   }
 
   slot_offset_type get_trim_pos() const
   {
-    return impl_.get_trim_pos();
+    return this->impl_.get_trim_pos();
   }
 
   StatusOr<slot_offset_type> await_trim_pos(slot_offset_type trim_pos)
   {
-    return impl_.await_trim_pos(trim_pos);
+    return this->impl_.await_trim_pos(trim_pos);
   }
 
   //----
@@ -63,41 +63,51 @@ class BasicLogStorageDriver
 
   slot_offset_type get_flush_pos() const
   {
-    return impl_.get_flush_pos();
+    return this->impl_.get_flush_pos();
   }
 
   StatusOr<slot_offset_type> await_flush_pos(slot_offset_type flush_pos)
   {
-    return impl_.await_flush_pos(flush_pos);
+    return this->impl_.await_flush_pos(flush_pos);
   }
 
   //----
 
   Status set_commit_pos(slot_offset_type commit_pos)
   {
-    return impl_.set_commit_pos(commit_pos);
+    return this->impl_.set_commit_pos(commit_pos);
   }
 
   slot_offset_type get_commit_pos() const
   {
-    return impl_.get_commit_pos();
+    return this->impl_.get_commit_pos();
   }
 
   StatusOr<slot_offset_type> await_commit_pos(slot_offset_type commit_pos)
   {
-    return impl_.await_commit_pos(commit_pos);
+    return this->impl_.await_commit_pos(commit_pos);
   }
 
   //----
 
   Status open()
   {
-    return impl_.open();
+    return this->impl_.open();
   }
 
   Status close()
   {
-    return impl_.close();
+    return this->impl_.close();
+  }
+
+  void halt()
+  {
+    this->impl_.halt();
+  }
+
+  void join()
+  {
+    this->impl_.join();
   }
   //
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/basic_ring_buffer_log_device.hpp
+++ b/src/llfs/basic_ring_buffer_log_device.hpp
@@ -13,6 +13,7 @@
 #include <llfs/basic_log_storage_driver.hpp>
 #include <llfs/basic_log_storage_reader.hpp>
 #include <llfs/log_device.hpp>
+#include <llfs/log_storage_driver_context.hpp>
 #include <llfs/ring_buffer.hpp>
 
 namespace llfs {
@@ -61,6 +62,16 @@ class BasicRingBufferLogDevice
   }
 
   Status close() override;
+
+  void halt() override
+  {
+    this->driver_.halt();
+  }
+
+  void join() override
+  {
+    this->driver_.join();
+  }
 
   Status sync(LogReadMode mode, SlotUpperBoundAt event) override;
 

--- a/src/llfs/basic_ring_buffer_log_device.hpp
+++ b/src/llfs/basic_ring_buffer_log_device.hpp
@@ -233,8 +233,6 @@ class BasicRingBufferLogDevice<Impl>::WriterImpl : public LogDevice::Writer
 
   StatusOr<MutableBuffer> prepare(usize byte_count, usize head_room) override
   {
-    BATT_CHECK(!this->prepared_offset_);
-
     if (this->device_->closed_.load()) {
       return ::llfs::make_status(StatusCode::kPrepareFailedLogClosed);
     }

--- a/src/llfs/data_reader.hpp
+++ b/src/llfs/data_reader.hpp
@@ -26,6 +26,7 @@
 #include <llfs/logging.hpp>
 
 #include <batteries/assert.hpp>
+#include <batteries/slice.hpp>
 #include <batteries/type_traits.hpp>
 
 #include <boost/range/iterator_range.hpp>
@@ -96,6 +97,18 @@ class DataReader
   void reset_flags()
   {
     at_end_ = false;
+  }
+
+  bool read_token(const batt::Slice<const u8>& token) noexcept
+  {
+    if (this->bytes_available() < token.size()) {
+      return false;
+    }
+    if (std::memcmp(this->unread_.begin(), token.begin(), token.size()) != 0) {
+      return false;
+    }
+    this->unread_.advance_begin(token.size());
+    return true;
   }
 
   template <typename T>
@@ -238,6 +251,11 @@ class DataReader
   ConstBuffer unread_data() const
   {
     return ConstBuffer{this->unread_.begin(), this->unread_.size()};
+  }
+
+  const u8* unread_begin() const
+  {
+    return this->unread_.begin();
   }
 
  private:

--- a/src/llfs/data_reader.hpp
+++ b/src/llfs/data_reader.hpp
@@ -99,6 +99,10 @@ class DataReader
     at_end_ = false;
   }
 
+  /** \brief Tries to consume a prefix of the remaining input that exactly matches `token`.
+   *
+   * \return true iff the unread data begins with token and this prefix is successfully consumed.
+   */
   bool read_token(const batt::Slice<const u8>& token) noexcept
   {
     if (this->bytes_available() < token.size()) {
@@ -253,6 +257,8 @@ class DataReader
     return ConstBuffer{this->unread_.begin(), this->unread_.size()};
   }
 
+  /** \brief Returns a pointer to the start of unread data.
+   */
   const u8* unread_begin() const
   {
     return this->unread_.begin();

--- a/src/llfs/file_log_driver.cpp
+++ b/src/llfs/file_log_driver.cpp
@@ -342,8 +342,23 @@ StatusOr<slot_offset_type> FileLogDriver::await_commit_pos(slot_offset_type min_
 //
 Status FileLogDriver::close()
 {
-  this->shared_state_.halt();
+  this->halt();
+  this->join();
 
+  return OkStatus();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void FileLogDriver::halt()
+{
+  this->shared_state_.halt();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void FileLogDriver::join()
+{
   if (this->trim_task_) {
     this->trim_task_->join();
     this->trim_task_ = None;
@@ -352,8 +367,6 @@ Status FileLogDriver::close()
     this->flush_task_->join();
     this->flush_task_ = None;
   }
-
-  return OkStatus();
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/file_log_driver.hpp
+++ b/src/llfs/file_log_driver.hpp
@@ -189,6 +189,10 @@ class FileLogDriver
 
   Status close();
 
+  void halt();
+
+  void join();
+
  private:
   // See <llfs/file_log_driver/concurrent_shared_state.cpp>
   //

--- a/src/llfs/ioring_log_config.cpp
+++ b/src/llfs/ioring_log_config.cpp
@@ -32,7 +32,8 @@ namespace llfs {
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 /*static*/ IoRingLogConfig IoRingLogConfig::from_logical_size(u64 logical_size,
-                                                              Optional<usize> opt_block_size)
+                                                              Optional<usize> opt_block_size,
+                                                              Optional<i64> opt_physical_offset)
 {
   const usize block_size = opt_block_size.value_or(IoRingLogConfig::kDefaultBlockSize);
   const i32 block_size_log2 = batt::log2_ceil(block_size);
@@ -41,7 +42,7 @@ namespace llfs {
 
   return IoRingLogConfig{
       .logical_size = logical_size,
-      .physical_offset = 0,
+      .physical_offset = opt_physical_offset.value_or(0),
       .physical_size =
           LogBlockCalculator::disk_size_required_for_log_size(logical_size, block_size),
       .pages_per_block_log2 = block_size_log2 - kLogPageSizeLog2,

--- a/src/llfs/ioring_log_config.cpp
+++ b/src/llfs/ioring_log_config.cpp
@@ -11,6 +11,7 @@
 
 #ifndef LLFS_DISABLE_IO_URING
 
+#include <llfs/log_block_calculator.hpp>
 #include <llfs/log_device_config.hpp>
 
 namespace llfs {
@@ -25,6 +26,25 @@ namespace llfs {
       .physical_offset = packed_config.absolute_block_0_offset(),
       .physical_size = packed_config->physical_size,
       .pages_per_block_log2 = packed_config->pages_per_block_log2,
+  };
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*static*/ IoRingLogConfig IoRingLogConfig::from_logical_size(u64 logical_size,
+                                                              Optional<usize> opt_block_size)
+{
+  const usize block_size = opt_block_size.value_or(IoRingLogConfig::kDefaultBlockSize);
+  const i32 block_size_log2 = batt::log2_ceil(block_size);
+
+  BATT_CHECK_GE(block_size_log2, kLogPageSizeLog2);
+
+  return IoRingLogConfig{
+      .logical_size = logical_size,
+      .physical_offset = 0,
+      .physical_size =
+          LogBlockCalculator::disk_size_required_for_log_size(logical_size, block_size),
+      .pages_per_block_log2 = block_size_log2 - kLogPageSizeLog2,
   };
 }
 

--- a/src/llfs/ioring_log_config.hpp
+++ b/src/llfs/ioring_log_config.hpp
@@ -14,6 +14,7 @@
 #include <llfs/constants.hpp>
 #include <llfs/file_offset_ptr.hpp>
 #include <llfs/int_types.hpp>
+#include <llfs/optional.hpp>
 #include <llfs/packed_log_page_header.hpp>
 
 namespace llfs {
@@ -44,7 +45,7 @@ struct IoRingLogConfig {
   u64 physical_size;
 
   // Specifies the size of a "flush block," the size of a single write operation while flushing,
-  // in number of 4kb pages, log2.  For example:
+  // in number of 512 byte pages, log2.  For example:
   //
   //  | flush_block_pages_log2   | flush write buffer size   |
   //  |--------------------------|---------------------------|
@@ -63,6 +64,8 @@ struct IoRingLogConfig {
 
   static IoRingLogConfig from_packed(
       const FileOffsetPtr<const PackedLogDeviceConfig&>& packed_config);
+
+  static IoRingLogConfig from_logical_size(u64 logical_size, Optional<usize> opt_block_size = None);
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/llfs/ioring_log_config.hpp
+++ b/src/llfs/ioring_log_config.hpp
@@ -45,7 +45,8 @@ struct IoRingLogConfig {
   u64 physical_size;
 
   // Specifies the size of a "flush block," the size of a single write operation while flushing,
-  // in number of 512 byte pages, log2.  For example:
+  // in number of kLogAtomicWriteSize (default=512; see llfs/config.hpp) byte pages, log2.  For
+  // example:
   //
   //  | flush_block_pages_log2   | flush write buffer size   |
   //  |--------------------------|---------------------------|
@@ -65,7 +66,14 @@ struct IoRingLogConfig {
   static IoRingLogConfig from_packed(
       const FileOffsetPtr<const PackedLogDeviceConfig&>& packed_config);
 
-  static IoRingLogConfig from_logical_size(u64 logical_size, Optional<usize> opt_block_size = None);
+  /** \brief Constructs and returns a config based on a given logical size.
+   *
+   * The block size is assumed to be IoRingLogConfig::kDefaultBlockSize unless otherwise specified.
+   * The physical offset is assumed to be 0 unless otherwise specified.  In all cases physical size
+   * is derived from logical size and block size.
+   */
+  static IoRingLogConfig from_logical_size(u64 logical_size, Optional<usize> opt_block_size = None,
+                                           Optional<i64> opt_physical_offset = None);
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/llfs/ioring_log_config.hpp
+++ b/src/llfs/ioring_log_config.hpp
@@ -68,9 +68,11 @@ struct IoRingLogConfig {
 
   /** \brief Constructs and returns a config based on a given logical size.
    *
-   * The block size is assumed to be IoRingLogConfig::kDefaultBlockSize unless otherwise specified.
-   * The physical offset is assumed to be 0 unless otherwise specified.  In all cases physical size
-   * is derived from logical size and block size.
+   * The block size defaults to IoRingLogConfig::kDefaultBlockSize.
+   * The physical offset defaults to 0.
+   * In all cases physical size is derived from logical size and block size.
+   *
+   * \return the new IoRingLogConfig
    */
   static IoRingLogConfig from_logical_size(u64 logical_size, Optional<usize> opt_block_size = None,
                                            Optional<i64> opt_physical_offset = None);

--- a/src/llfs/ioring_log_device.hpp
+++ b/src/llfs/ioring_log_device.hpp
@@ -69,7 +69,14 @@ class IoRingLogDeviceFactory : public LogDeviceFactory
 
     BATT_ASSIGN_OK_RESULT(DefaultIoRingLogDeviceStorage storage,
                           DefaultIoRingLogDeviceStorage::make_new(
-                              MaxQueueDepth{calculate.queue_depth() * 2}, this->fd_));
+                              MaxQueueDepth{
+                                  calculate.queue_depth() * 2
+                                  //
+                                  // Double the number of flush ops, to give us some margin so the
+                                  // rings don't ever run out of space (TODO [tastolfi 2024-05-14]
+                                  // this seems excessive; investigate lowering this)
+                              },
+                              this->fd_));
 
     this->fd_ = -1;
 

--- a/src/llfs/ioring_log_device.hpp
+++ b/src/llfs/ioring_log_device.hpp
@@ -20,6 +20,7 @@
 #include <llfs/file_offset_ptr.hpp>
 #include <llfs/ioring.hpp>
 #include <llfs/ioring_log_config.hpp>
+#include <llfs/ioring_log_device_storage.hpp>
 #include <llfs/ioring_log_driver.hpp>
 #include <llfs/ioring_log_driver_options.hpp>
 #include <llfs/ioring_log_flush_op.hpp>
@@ -64,11 +65,17 @@ class IoRingLogDeviceFactory : public LogDeviceFactory
 
   StatusOr<std::unique_ptr<IoRingLogDevice>> open_ioring_log_device()
   {
-    auto instance = std::make_unique<IoRingLogDevice>(
-        RingBuffer::TempFile{.byte_size = this->config_.logical_size}, this->task_scheduler_,
-        this->fd_, this->config_, this->options_);
+    LogBlockCalculator calculate{this->config_, this->options_};
+
+    BATT_ASSIGN_OK_RESULT(DefaultIoRingLogDeviceStorage storage,
+                          DefaultIoRingLogDeviceStorage::make_new(
+                              MaxQueueDepth{calculate.queue_depth() * 2}, this->fd_));
 
     this->fd_ = -1;
+
+    auto instance = std::make_unique<IoRingLogDevice>(
+        RingBuffer::TempFile{.byte_size = this->config_.logical_size}, this->task_scheduler_,
+        std::move(storage), this->config_, this->options_);
 
     Status open_status = instance->open();
     BATT_REQUIRE_OK(open_status);

--- a/src/llfs/ioring_log_device_storage.cpp
+++ b/src/llfs/ioring_log_device_storage.cpp
@@ -1,0 +1,71 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/ioring_log_device_storage.hpp>
+//
+
+namespace llfs {
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*static*/ StatusOr<DefaultIoRingLogDeviceStorage> DefaultIoRingLogDeviceStorage::make_new(
+    MaxQueueDepth entries, int fd)
+{
+  BATT_ASSIGN_OK_RESULT(IoRing io_ring, IoRing::make_new(entries));
+  BATT_ASSIGN_OK_RESULT(IoRing::File file, IoRing::File::open(io_ring, fd));
+
+  return DefaultIoRingLogDeviceStorage{std::move(io_ring), std::move(file)};
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*explicit*/ DefaultIoRingLogDeviceStorage::DefaultIoRingLogDeviceStorage(
+    IoRing&& io_ring, IoRing::File&& file) noexcept
+    : io_ring_{std::move(io_ring)}
+    , file_{std::move(file)}
+{
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*explicit*/ DefaultIoRingLogDeviceStorage::EventLoopTask::EventLoopTask(
+    DefaultIoRingLogDeviceStorage& storage, std::string_view caller) noexcept
+    : storage_{storage}
+    , caller_{caller}
+    , thread_{[this] {
+      LLFS_VLOG(1) << "(" << this->caller_ << ") invoking IoRing::run()";
+
+      Status io_status = this->storage_.io_ring_.run();
+      if (!io_status.ok()) {
+        LLFS_LOG_WARNING() << "(" << this->caller_ << ") IoRing::run() returned: " << io_status;
+      }
+      this->done_.set_value(true);
+
+      LLFS_VLOG(1) << "(" << this->caller_ << ") IoRing::run() returned; exiting event loop thread";
+    }}
+{
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+DefaultIoRingLogDeviceStorage::EventLoopTask::~EventLoopTask() noexcept
+{
+  BATT_CHECK(this->join_called_);
+  BATT_CHECK(this->done_.get_value());
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void DefaultIoRingLogDeviceStorage::EventLoopTask::join()
+{
+  this->join_called_ = true;
+  BATT_CHECK_OK(this->done_.await_equal(true));
+  this->thread_.join();
+}
+
+}  //namespace llfs

--- a/src/llfs/ioring_log_device_storage.hpp
+++ b/src/llfs/ioring_log_device_storage.hpp
@@ -1,0 +1,117 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_IORING_LOG_DEVICE_STORAGE_HPP
+#define LLFS_IORING_LOG_DEVICE_STORAGE_HPP
+
+#include <llfs/config.hpp>
+//
+#include <llfs/ioring.hpp>
+#include <llfs/ioring_file.hpp>
+#include <llfs/status.hpp>
+
+namespace llfs {
+
+class DefaultIoRingLogDeviceStorage
+{
+ public:
+  static StatusOr<DefaultIoRingLogDeviceStorage> make_new(MaxQueueDepth entries, int fd)
+  {
+    BATT_ASSIGN_OK_RESULT(IoRing io_ring, IoRing::make_new(entries));
+    BATT_ASSIGN_OK_RESULT(IoRing::File file, IoRing::File::open(io_ring, fd));
+
+    return DefaultIoRingLogDeviceStorage{std::move(io_ring), std::move(file)};
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  DefaultIoRingLogDeviceStorage(const DefaultIoRingLogDeviceStorage&) = delete;
+  DefaultIoRingLogDeviceStorage& operator=(const DefaultIoRingLogDeviceStorage&) = delete;
+
+  DefaultIoRingLogDeviceStorage(DefaultIoRingLogDeviceStorage&&) = default;
+  DefaultIoRingLogDeviceStorage& operator=(DefaultIoRingLogDeviceStorage&&) = default;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  Status register_fd()
+  {
+    return this->file_.register_fd();
+  }
+
+  StatusOr<usize> register_buffers(batt::BoxedSeq<MutableBuffer>&& buffers,
+                                   bool update = false) const noexcept
+  {
+    return this->io_ring_.register_buffers(std::move(buffers), update);
+  }
+
+  Status close()
+  {
+    return this->file_.close();
+  }
+
+  void on_work_started() const noexcept
+  {
+    this->io_ring_.on_work_started();
+  }
+
+  void on_work_finished() const noexcept
+  {
+    this->io_ring_.on_work_finished();
+  }
+
+  Status run_event_loop() const noexcept
+  {
+    return this->io_ring_.run();
+  }
+
+  void reset_event_loop() const noexcept
+  {
+    this->io_ring_.reset();
+  }
+
+  template <typename Handler = void(StatusOr<i32>)>
+  void post_to_event_loop(Handler&& handler) const noexcept
+  {
+    this->io_ring_.post(BATT_FORWARD(handler));
+  }
+
+  void stop_event_loop() const noexcept
+  {
+    this->io_ring_.stop();
+  }
+
+  Status read_all(i64 offset, MutableBuffer buffer)
+  {
+    return this->file_.read_all(offset, buffer);
+  }
+
+  template <typename Handler>
+  void async_write_some_fixed(i64 file_offset, const ConstBuffer& data, i32 buf_index,
+                              Handler&& handler)
+  {
+    this->file_.async_write_some_fixed(file_offset, data, buf_index, BATT_FORWARD(handler));
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+ private:
+  explicit DefaultIoRingLogDeviceStorage(IoRing&& io_ring, IoRing::File&& file) noexcept
+      : io_ring_{std::move(io_ring)}
+      , file_{std::move(file)}
+  {
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   --
+
+  IoRing io_ring_;
+  IoRing::File file_;
+};
+
+}  //namespace llfs
+
+#endif  // LLFS_IORING_LOG_DEVICE_FILE_HPP

--- a/src/llfs/ioring_log_driver.hpp
+++ b/src/llfs/ioring_log_driver.hpp
@@ -108,19 +108,7 @@ class BasicIoRingLogDriver
     return this->flush_pos_.get_value();
   }
 
-  StatusOr<slot_offset_type> await_flush_pos(slot_offset_type flush_pos)
-  {
-    StatusOr<slot_offset_type> status_or = await_slot_offset(flush_pos, this->flush_pos_);
-
-    // If the flush_pos Watch has been closed, it may indicate there was an I/O error; check the
-    // LogStorageDriverContext and report any error status we find.
-    //
-    if (status_or.status() == batt::StatusCode::kClosed) {
-      BATT_REQUIRE_OK(this->context_.get_error_status());
-    }
-
-    return status_or;
-  }
+  StatusOr<slot_offset_type> await_flush_pos(slot_offset_type flush_pos);
 
   //----
 
@@ -276,7 +264,7 @@ class BasicIoRingLogDriver
    */
   void storage_work_started();
 
-  /** \brief Signals that storage I/O work is now the in process of shutting down.  The first time
+  /** \brief Signals that storage I/O work is now in the process of shutting down.  The first time
    * this is called (after this->storage_work_started()), calls this->storage_.on_work_finished() to
    * decrement the work count, allowing the storage I/O event loop to exit once all activity has
    * completed.

--- a/src/llfs/ioring_log_driver.ipp
+++ b/src/llfs/ioring_log_driver.ipp
@@ -89,7 +89,7 @@ inline Status BasicIoRingLogDriver<FlushOpImpl, StorageT>::open()
   }
 
   StatusOr<usize> buffers_registered = this->storage_.register_buffers(
-      as_seq(this->flush_ops_) | seq::map([](const IoRingLogFlushOp& op) {
+      as_seq(this->flush_ops_) | seq::map([](const Self::FlushOp& op) {
         return op.get_buffer();
       }) |
       seq::boxed());

--- a/src/llfs/ioring_log_driver.ipp
+++ b/src/llfs/ioring_log_driver.ipp
@@ -196,6 +196,24 @@ inline Status BasicIoRingLogDriver<FlushOpImpl, StorageT>::set_trim_pos(slot_off
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 template <template <typename> class FlushOpImpl, typename StorageT>
+inline StatusOr<slot_offset_type> BasicIoRingLogDriver<FlushOpImpl, StorageT>::await_flush_pos(
+    slot_offset_type flush_pos)
+{
+  StatusOr<slot_offset_type> status_or = await_slot_offset(flush_pos, this->flush_pos_);
+
+  // If the flush_pos Watch has been closed, it may indicate there was an I/O error; check the
+  // LogStorageDriverContext and report any error status we find.
+  //
+  if (status_or.status() == batt::StatusCode::kClosed) {
+    BATT_REQUIRE_OK(this->context_.get_error_status());
+  }
+
+  return status_or;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+template <template <typename> class FlushOpImpl, typename StorageT>
 inline Status BasicIoRingLogDriver<FlushOpImpl, StorageT>::set_commit_pos(
     slot_offset_type commit_pos)
 {

--- a/src/llfs/ioring_log_driver.ipp
+++ b/src/llfs/ioring_log_driver.ipp
@@ -484,11 +484,9 @@ template <template <typename> class FlushOpImpl, typename StorageT>
 inline void BasicIoRingLogDriver<FlushOpImpl, StorageT>::storage_work_started()
 {
   const bool was_working = this->storage_working_.exchange(true);
-  if (!was_working) {
-    this->storage_.on_work_started();
-  } else {
-    LLFS_LOG_WARNING() << "storage started again?" << std::endl << boost::stacktrace::stacktrace{};
-  }
+  BATT_CHECK(!was_working);
+
+  this->storage_.on_work_started();
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -500,6 +498,9 @@ inline void BasicIoRingLogDriver<FlushOpImpl, StorageT>::storage_work_finished()
   if (was_working) {
     this->storage_.on_work_finished();
   }
+  // else:
+  //   Don't assert/check here, since there are multiple legitimate places where we could call
+  //   `on_work_finished`.
 }
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------

--- a/src/llfs/ioring_log_driver_fwd.hpp
+++ b/src/llfs/ioring_log_driver_fwd.hpp
@@ -6,17 +6,21 @@
 //
 //+++++++++++-+-+--+----- --- -- -  -  -   -
 
-#include <llfs/ioring_log_driver.hpp>
-//
+#pragma once
+#ifndef LLFS_IORING_LOG_DRIVER_FWD_HPP
+#define LLFS_IORING_LOG_DRIVER_FWD_HPP
 
-#ifndef LLFS_DISABLE_IO_URING
-
-#include <llfs/ioring_log_driver.ipp>
+#include <llfs/config.hpp>
 
 namespace llfs {
 
-template class BasicIoRingLogDriver<BasicIoRingLogFlushOp, DefaultIoRingLogDeviceStorage>;
+#ifndef LLFS_DISABLE_IO_URING
 
-}  // namespace llfs
+template <template <typename> class FlushOpImpl, typename StorageT>
+class BasicIoRingLogDriver;
 
 #endif  // LLFS_DISABLE_IO_URING
+
+}  //namespace llfs
+
+#endif  // LLFS_IORING_LOG_DRIVER_FWD_HPP

--- a/src/llfs/ioring_log_driver_options.hpp
+++ b/src/llfs/ioring_log_driver_options.hpp
@@ -68,6 +68,20 @@ class IoRingLogDriverOptions
     return *this;
   }
 
+  /** \brief Sets queue depth to the smallest power of 2 that is not greater than `max_n` *and* not
+   * greater than the current value of queue depth.
+   *
+   * `max_n` must be at least 2.
+   */
+  Self& limit_queue_depth(usize max_n)
+  {
+    BATT_CHECK_GT(max_n, 1);
+    while (this->queue_depth() > max_n) {
+      --this->queue_depth_log2;
+    }
+    return *this;
+  }
+
   usize queue_depth_mask() const
   {
     return this->queue_depth() - 1;

--- a/src/llfs/ioring_log_flush_op.hpp
+++ b/src/llfs/ioring_log_flush_op.hpp
@@ -40,12 +40,22 @@ class BasicIoRingLogFlushOp;
 using IoRingLogFlushOp = BasicIoRingLogFlushOp<
     BasicIoRingLogDriver<BasicIoRingLogFlushOp, DefaultIoRingLogDeviceStorage>>;
 
+/** \brief The global default setting for whether IoRingLogDevices should log failures at INFO or
+ * higher level by default.
+ *
+ * This exists mostly as a convenience for testing, so that the test output doesn't contain a large
+ * number of injected/simulated failure log messages.
+ */
 inline std::atomic<bool>& default_ioring_quiet_failure_logging()
 {
   static std::atomic<bool> be_quiet_{false};
   return be_quiet_;
 }
 
+/** \brief Flushes data from the in-memory ring buffer to log storage asynchronously.
+ *
+ * Concurrent flush operations are implemented by instantiating a number of objects of this type.
+ */
 template <typename DriverImpl>
 class BasicIoRingLogFlushOp
 {

--- a/src/llfs/ioring_log_flush_op.hpp
+++ b/src/llfs/ioring_log_flush_op.hpp
@@ -40,6 +40,12 @@ class BasicIoRingLogFlushOp;
 using IoRingLogFlushOp = BasicIoRingLogFlushOp<
     BasicIoRingLogDriver<BasicIoRingLogFlushOp, DefaultIoRingLogDeviceStorage>>;
 
+inline std::atomic<bool>& default_ioring_quiet_failure_logging()
+{
+  static std::atomic<bool> be_quiet_{false};
+  return be_quiet_;
+}
+
 template <typename DriverImpl>
 class BasicIoRingLogFlushOp
 {
@@ -151,7 +157,7 @@ class BasicIoRingLogFlushOp
     return this->debug_info_message_;
   }
 
-  std::atomic<bool> quiet_failure_logging{false};
+  std::atomic<bool> quiet_failure_logging{default_ioring_quiet_failure_logging().load()};
 
  private:
   // Return the committed data portion of the block buffer, aligned to 512-byte boundaries.

--- a/src/llfs/ioring_log_flush_op.hpp
+++ b/src/llfs/ioring_log_flush_op.hpp
@@ -17,6 +17,8 @@
 #include <llfs/data_layout.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/ioring.hpp>
+#include <llfs/ioring_log_device_storage.hpp>
+#include <llfs/ioring_log_driver_fwd.hpp>
 #include <llfs/log_block_calculator.hpp>
 #include <llfs/metrics.hpp>
 #include <llfs/packed_log_page_buffer.hpp>
@@ -35,10 +37,8 @@ namespace llfs {
 template <typename DriverImpl>
 class BasicIoRingLogFlushOp;
 
-template <template <typename> class FlushOpImpl>
-class BasicIoRingLogDriver;
-
-using IoRingLogFlushOp = BasicIoRingLogFlushOp<BasicIoRingLogDriver<BasicIoRingLogFlushOp>>;
+using IoRingLogFlushOp = BasicIoRingLogFlushOp<
+    BasicIoRingLogDriver<BasicIoRingLogFlushOp, DefaultIoRingLogDeviceStorage>>;
 
 template <typename DriverImpl>
 class BasicIoRingLogFlushOp

--- a/src/llfs/ioring_log_flush_op.test.cpp
+++ b/src/llfs/ioring_log_flush_op.test.cpp
@@ -393,6 +393,9 @@ class IoRingLogFlushOpModel
                                             ::testing::_ /*handler*/))
         .WillRepeatedly(::testing::InvokeArgument<1>(this->calculate_->block_count()));
 
+    EXPECT_CALL(*this->driver_, report_flush_error(::testing::_ /*error status*/))
+        .WillRepeatedly(::testing::Return());
+
     //----- --- -- -  -  -   -
 
     // Create the expected flush op state.

--- a/src/llfs/ioring_log_flush_op.test.hpp
+++ b/src/llfs/ioring_log_flush_op.test.hpp
@@ -75,6 +75,15 @@ class MockIoRingLogDriver
 
   MOCK_METHOD(void, poll_flush_state, (), ());
 
+  //----- --- -- -  -  -   -
+  // TODO [tastolfi 2024-05-08] implement this:
+  // MOCK_METHOD(void, report_flush_error, (Status), ());
+  //
+  void report_flush_error(Status)
+  {
+  }
+  //----- --- -- -  -  -   -
+
   MOCK_METHOD(void, update_init_upper_bound, (LogBlockCalculator::PhysicalBlockIndex), ());
 
   MOCK_METHOD(usize, get_init_upper_bound, (), (const));

--- a/src/llfs/ioring_log_flush_op.test.hpp
+++ b/src/llfs/ioring_log_flush_op.test.hpp
@@ -75,14 +75,7 @@ class MockIoRingLogDriver
 
   MOCK_METHOD(void, poll_flush_state, (), ());
 
-  //----- --- -- -  -  -   -
-  // TODO [tastolfi 2024-05-08] implement this:
-  // MOCK_METHOD(void, report_flush_error, (Status), ());
-  //
-  void report_flush_error(Status)
-  {
-  }
-  //----- --- -- -  -  -   -
+  MOCK_METHOD(void, report_flush_error, (Status), ());
 
   MOCK_METHOD(void, update_init_upper_bound, (LogBlockCalculator::PhysicalBlockIndex), ());
 

--- a/src/llfs/ioring_log_initializer.cpp
+++ b/src/llfs/ioring_log_initializer.cpp
@@ -50,7 +50,7 @@ Status initialize_ioring_log_device(RawBlockFile& file, const IoRingLogConfig& c
       BATT_REQUIRE_OK(init_status);
 
     } else {
-      LLFS_LOG_INFO() << "Using slow path for log device initialization";
+      LLFS_LOG_INFO_FIRST_N(10) << "Using slow path for log device initialization";
 
       PackedLogPageBuffer buffer;
       buffer.clear();

--- a/src/llfs/ioring_log_initializer.ipp
+++ b/src/llfs/ioring_log_initializer.ipp
@@ -57,14 +57,14 @@ inline batt::Status BasicIoRingLogInitializer<IoRingImpl>::run()
 
     // Map our memory buffer to the kernel for faster I/O.
     //
-    StatusOr<usize> buffers_status = this->file_.get_io_ring().register_buffers(
-        seq::single_item(std::move(memory)) | seq::boxed());
+    StatusOr<usize> buffers_status = this->file_.get_io_ring_impl()->register_buffers(
+        seq::single_item(std::move(memory)) | seq::boxed(), /*update=*/false);
 
     LLFS_VLOG(2) << "register_buffers status=" << buffers_status;
     BATT_REQUIRE_OK(buffers_status);
   }
   auto on_scope_exit = batt::finally([&] {
-    this->file_.get_io_ring().unregister_buffers().IgnoreError();
+    this->file_.get_io_ring_impl()->unregister_buffers().IgnoreError();
     LLFS_VLOG(1) << "IoRingLogInitializer::run() Finished";
   });
 

--- a/src/llfs/ioring_log_recovery.cpp
+++ b/src/llfs/ioring_log_recovery.cpp
@@ -45,7 +45,7 @@ Status IoRingLogRecovery::run()
        ++block_i, file_offset += this->config_.block_size()) {
     //----- --- -- -  -  -   -
     LLFS_VLOG(2) << "Reading " << BATT_INSPECT(block_i) << "/" << block_count << " from "
-                 << BATT_INSPECT(file_offset);
+                 << BATT_INSPECT(file_offset) << BATT_INSPECT(this->block_buffer().size());
 
     BATT_CHECK_LE(known_valid_blocks, block_count);
 

--- a/src/llfs/ioring_log_recovery.cpp
+++ b/src/llfs/ioring_log_recovery.cpp
@@ -10,6 +10,7 @@
 //
 #include <llfs/data_reader.hpp>
 #include <llfs/logging.hpp>
+#include <llfs/slot_writer.hpp>
 
 #include <batteries/stream_util.hpp>
 
@@ -210,6 +211,12 @@ void IoRingLogRecovery::recover_block_data()
 //
 void IoRingLogRecovery::recover_flush_pos()
 {
+  const static usize kBeginAtomicTokenSize =  //
+      SlotWriter::WriterLock::begin_atomic_range_token().size();
+
+  const static usize kEndAtomicTokenSize =  //
+      SlotWriter::WriterLock::end_atomic_range_token().size();
+
   LLFS_VLOG(1) << "IoRingLogRecovery::recover_flush_pos()";
 
   // Start at the trim pos and step forward through the recovered data, slot by slot, to discover
@@ -250,6 +257,10 @@ void IoRingLogRecovery::recover_flush_pos()
 
   ConstBuffer committed_bytes = resize_buffer(this->ring_buffer_.get(slot_offset),
                                               committed_ranges.front().offset_range.size());
+
+  slot_offset_type confirmed_flush_pos = slot_offset;
+  bool inside_atomic_range = false;
+
   for (;;) {
     LLFS_VLOG_EVERY_N(2, kUpdateCadence)
         << " -- attempting to recover log entry at " << BATT_INSPECT(slot_offset);
@@ -286,13 +297,31 @@ void IoRingLogRecovery::recover_flush_pos()
                    << BATT_INSPECT(slot_size);
       break;
     }
+
+    // Check for control token; this indicates the beginning or end of an atomic slot range.
+    //
+    if (*slot_body_size == 0) {
+      if (slot_header_size == kBeginAtomicTokenSize) {
+        inside_atomic_range = true;
+      } else if (slot_header_size == kEndAtomicTokenSize) {
+        inside_atomic_range = false;
+      }
+    }
+
     committed_bytes += slot_size;
     slot_offset += slot_size;
+
+    // If inside an atomic slot range, we hold off on updating the confirmed_flush_pos, just in case
+    // the flushed data is cut off before the end of the atomic range.
+    //
+    if (!inside_atomic_range) {
+      confirmed_flush_pos = slot_offset;
+    }
   }
 
   LLFS_VLOG(1) << " -- Slot scan complete;" << BATT_INSPECT(slot_offset);
 
-  this->flush_pos_ = slot_offset;
+  this->flush_pos_ = confirmed_flush_pos;
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/ioring_log_recovery.cpp
+++ b/src/llfs/ioring_log_recovery.cpp
@@ -211,12 +211,6 @@ void IoRingLogRecovery::recover_block_data()
 //
 void IoRingLogRecovery::recover_flush_pos()
 {
-  const static usize kBeginAtomicTokenSize =  //
-      SlotWriter::WriterLock::begin_atomic_range_token().size();
-
-  const static usize kEndAtomicTokenSize =  //
-      SlotWriter::WriterLock::end_atomic_range_token().size();
-
   LLFS_VLOG(1) << "IoRingLogRecovery::recover_flush_pos()";
 
   // Start at the trim pos and step forward through the recovered data, slot by slot, to discover
@@ -301,9 +295,9 @@ void IoRingLogRecovery::recover_flush_pos()
     // Check for control token; this indicates the beginning or end of an atomic slot range.
     //
     if (*slot_body_size == 0) {
-      if (slot_header_size == kBeginAtomicTokenSize) {
+      if (slot_header_size == SlotWriter::WriterLock::kBeginAtomicRangeTokenSize) {
         inside_atomic_range = true;
-      } else if (slot_header_size == kEndAtomicTokenSize) {
+      } else if (slot_header_size == SlotWriter::WriterLock::kEndAtomicRangeTokenSize) {
         inside_atomic_range = false;
       }
     }

--- a/src/llfs/latching_bit_set.test.cpp
+++ b/src/llfs/latching_bit_set.test.cpp
@@ -32,7 +32,7 @@ TEST(LatchingBitSetTest, Size0)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-TEST(LatchingBitSetTest, Size1)
+TEST(LatchingBitSetTest, Size1Death)
 {
   llfs::LatchingBitSet s{1};
 

--- a/src/llfs/log_device_config.cpp
+++ b/src/llfs/log_device_config.cpp
@@ -78,9 +78,11 @@ Status configure_storage_object(StorageFileBuilder::Transaction& txn,
 //
 StatusOr<std::unique_ptr<IoRingLogDeviceFactory>> recover_storage_object(
     const batt::SharedPtr<StorageContext>& storage_context, const std::string& file_name,
-    const FileOffsetPtr<const PackedLogDeviceConfig&>& p_config,
-    const IoRingLogDriverOptions& options)
+    const FileOffsetPtr<const PackedLogDeviceConfig&>& p_config, IoRingLogDriverOptions options)
 {
+  BATT_ASSIGN_OK_RESULT(usize block_count, p_config->block_count());
+  options.limit_queue_depth(block_count);
+
   const int flags = O_DIRECT | O_SYNC | O_RDWR;
 
   int fd = batt::syscall_retry([&] {

--- a/src/llfs/log_storage_driver_context.hpp
+++ b/src/llfs/log_storage_driver_context.hpp
@@ -10,7 +10,12 @@
 #ifndef LLFS_LOG_STORAGE_DRIVER_CONTEXT_HPP
 #define LLFS_LOG_STORAGE_DRIVER_CONTEXT_HPP
 
+#include <llfs/config.hpp>
+//
 #include <llfs/ring_buffer.hpp>
+#include <llfs/status.hpp>
+
+#include <batteries/async/mutex.hpp>
 
 #include <atomic>
 
@@ -21,7 +26,35 @@ struct LogStorageDriverContext {
   {
   }
 
+  /** \brief Updates the stored error status with the passed value.
+   */
+  void update_error_status(Status status) noexcept
+  {
+    batt::ScopedLock<Status> locked{this->error_status_};
+
+    locked->Update(status);
+  }
+
+  /** \brief Sets the stored error status to the passed value.
+   */
+  void set_error_status(Status status) noexcept
+  {
+    batt::ScopedLock<Status> locked{this->error_status_};
+
+    *locked = status;
+  }
+
+  /** \brief Returns the stored error status.
+   */
+  Status get_error_status() noexcept
+  {
+    batt::ScopedLock<Status> locked{this->error_status_};
+
+    return *locked;
+  }
+
   std::atomic<bool> closed_{false};
+  batt::Mutex<Status> error_status_{OkStatus()};
   RingBuffer buffer_;
 };
 

--- a/src/llfs/memory_log_device.hpp
+++ b/src/llfs/memory_log_device.hpp
@@ -85,11 +85,22 @@ class MemoryLogStorageDriver /*Impl*/
 
   Status close()
   {
+    this->halt();
+    this->join();
+
+    return OkStatus();
+  }
+
+  void halt()
+  {
     this->trim_pos_.close();
     this->manual_flush_pos_.close();
     this->commit_pos_.close();
+  }
 
-    return OkStatus();
+  void join()
+  {
+    // Nothing to do.
   }
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/packed_log_page_buffer.hpp
+++ b/src/llfs/packed_log_page_buffer.hpp
@@ -10,12 +10,15 @@
 #ifndef LLFS_PACKED_LOG_PAGE_BUFFER_HPP
 #define LLFS_PACKED_LOG_PAGE_BUFFER_HPP
 
-#include <llfs/buffer.hpp>
 #include <llfs/config.hpp>
+//
+#include <llfs/buffer.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/packed_log_page_header.hpp>
 
 #include <batteries/static_assert.hpp>
+
+#include <type_traits>
 
 namespace llfs {
 

--- a/src/llfs/packed_status_or.test.cpp
+++ b/src/llfs/packed_status_or.test.cpp
@@ -19,7 +19,7 @@ namespace {
 
 using namespace llfs::int_types;
 
-TEST(PackedStatusOrTest, PackUnPack)
+TEST(PackedStatusOrTest, PackUnPackDeath)
 {
   batt::Status not_found_status{batt::StatusCode::kNotFound};
 

--- a/src/llfs/page_allocator.cpp
+++ b/src/llfs/page_allocator.cpp
@@ -169,7 +169,7 @@ void PageAllocator::halt() noexcept
   this->stop_requested_.set_value(true);
 
   this->slot_writer_.halt();
-  this->log_device_->close().IgnoreError();
+  this->log_device_->halt();
   this->state_->halt();
   this->checkpoint_grant_.revoke();
 }
@@ -177,6 +177,7 @@ void PageAllocator::halt() noexcept
 void PageAllocator::join() noexcept
 {
   this->checkpoint_task_.join();
+  this->log_device_->join();
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/page_allocator.test.cpp
+++ b/src/llfs/page_allocator.test.cpp
@@ -13,9 +13,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <llfs/testing/fake_log_device.hpp>
+#include <llfs/testing/test_config.hpp>
+
 #include <llfs/log_device_snapshot.hpp>
 #include <llfs/memory_log_device.hpp>
-#include <llfs/testing/fake_log_device.hpp>
 #include <llfs/uuid.hpp>
 
 #include <batteries/async/fake_execution_context.hpp>
@@ -137,6 +139,8 @@ TEST(PageAllocatorTest, UpdateRefCounts)
 
 TEST(PageAllocatorTest, LogCrashRecovery)
 {
+  llfs::testing::TestConfig test_config;
+
   llfs::suppress_log_output_for_test() = true;
   auto undo_suppress = batt::finally([] {
     llfs::suppress_log_output_for_test() = false;
@@ -152,7 +156,7 @@ TEST(PageAllocatorTest, LogCrashRecovery)
   std::uniform_int_distribution<i32> pick_ref_count_delta(-5, +5);
   std::uniform_int_distribution<u64> pick_failure_time(1u, 4096u);
 
-  const bool extra_testing = batt::getenv_as<int>("LLFS_EXTRA_TESTING").value_or(0);
+  const bool extra_testing = test_config.extra_testing();
 
   constexpr u64 kStartSeed = 0;
   const u64 kEndSeed = (extra_testing ? (10000 * kNumSeeds) : kNumSeeds) + kStartSeed;

--- a/src/llfs/page_allocator.test.cpp
+++ b/src/llfs/page_allocator.test.cpp
@@ -185,8 +185,6 @@ TEST(PageAllocatorTest, LogCrashRecovery)
         /*size=*/PageAllocator::calculate_log_size(/*physical_page_count=*/kNumPages,
                                                    /*max_attachments=*/kMaxAttachments)};
 
-    LLFS_LOG_INFO_FIRST_N(1) << BATT_INSPECT(mem_log.space());
-
     auto fake_log_state = std::make_shared<FakeLogDevice::State>();
 
     FakeLogDeviceFactory<MemoryLogStorageDriver> fake_log_factory{mem_log, mem_log.driver().impl(),

--- a/src/llfs/page_arena.hpp
+++ b/src/llfs/page_arena.hpp
@@ -49,7 +49,7 @@ class PageArena
     return *this->allocator_;
   }
 
-  void close()
+  void halt()
   {
     // this->device_->close();  TODO [tastolfi 2021-04-07]
     this->allocator_->halt();

--- a/src/llfs/page_cache.cpp
+++ b/src/llfs/page_cache.cpp
@@ -255,7 +255,7 @@ void PageCache::close()
 {
   for (const std::unique_ptr<PageDeviceEntry>& entry : this->page_devices_) {
     if (entry) {
-      entry->arena.close();
+      entry->arena.halt();
     }
   }
 }

--- a/src/llfs/page_cache.hpp
+++ b/src/llfs/page_cache.hpp
@@ -166,6 +166,8 @@ class PageCache : public PageLoader
 
   void close();
 
+  void halt();
+
   void join();
 
   std::unique_ptr<PageCacheJob> new_job();

--- a/src/llfs/page_cache_slot.test.cpp
+++ b/src/llfs/page_cache_slot.test.cpp
@@ -64,7 +64,7 @@ class PageCacheSlotTest : public ::testing::Test
 //  1. Create slots with different index values in a Pool; verify index()
 //     - also verify initial is_valid state
 //
-TEST_F(PageCacheSlotTest, CreateSlots)
+TEST_F(PageCacheSlotTest, CreateSlotsDeath)
 {
   for (usize i = 0; i < kNumTestSlots; ++i) {
     llfs::PageCacheSlot* slot = this->pool_->allocate();
@@ -89,7 +89,7 @@ TEST_F(PageCacheSlotTest, CreateSlots)
 //  2. ref_count test - add_ref/remove_ref should affect the ref_count, and also the use count of
 //     the pool but only in the case of add: 0 -> 1 and remove: 1 -> 0.
 //
-TEST_F(PageCacheSlotTest, AddRemoveRef)
+TEST_F(PageCacheSlotTest, AddRemoveRefDeath)
 {
   EXPECT_EQ(this->pool_->use_count(), 1u);
 
@@ -373,7 +373,7 @@ TEST_F(PageCacheSlotTest, EvictIfKeyEqualsFailureWrongKey)
 //     a. Valid + Filled
 //     c. Valid + Filled + Pinned
 //
-TEST_F(PageCacheSlotTest, FillFailureAlreadyFilled)
+TEST_F(PageCacheSlotTest, FillFailureAlreadyFilledDeath)
 {
   llfs::PageCacheSlot* slot = this->pool_->allocate();
   {
@@ -391,7 +391,7 @@ TEST_F(PageCacheSlotTest, FillFailureAlreadyFilled)
 //  7. fill fails when state is not Invalid:
 //     b. Valid + Cleared
 //
-TEST_F(PageCacheSlotTest, FillFailureCleared)
+TEST_F(PageCacheSlotTest, FillFailureClearedDeath)
 {
   llfs::PageCacheSlot* slot = this->pool_->allocate();
 

--- a/src/llfs/simulated_log_device_storage.cpp
+++ b/src/llfs/simulated_log_device_storage.cpp
@@ -8,9 +8,17 @@
 
 #include <llfs/simulated_log_device_storage.hpp>
 //
+#include <llfs/ioring_log_driver.hpp>
+#include <llfs/ioring_log_driver.ipp>
+#include <llfs/ioring_log_flush_op.hpp>
+#include <llfs/ioring_log_flush_op.ipp>
 #include <llfs/storage_simulation.hpp>
 
 namespace llfs {
+
+template class BasicIoRingLogDriver<BasicIoRingLogFlushOp, SimulatedLogDeviceStorage>;
+template class BasicIoRingLogFlushOp<
+    BasicIoRingLogDriver<BasicIoRingLogFlushOp, SimulatedLogDeviceStorage>>;
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
@@ -78,6 +86,15 @@ void SimulatedLogDeviceStorage::EphemeralState::async_write_some_fixed(
 void SimulatedLogDeviceStorage::EphemeralState::simulation_post(std::function<void()>&& fn)
 {
   this->simulation_.post(std::move(fn));
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*explicit*/ SimulatedLogDeviceStorage::RawBlockFileImpl::RawBlockFileImpl(
+    std::shared_ptr<DurableState>&& durable_state) noexcept
+    : durable_state_{std::move(durable_state)}
+    , creation_step_{this->durable_state_->simulation().current_step()}
+{
 }
 
 }  //namespace llfs

--- a/src/llfs/simulated_log_device_storage.cpp
+++ b/src/llfs/simulated_log_device_storage.cpp
@@ -1,0 +1,83 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/simulated_log_device_storage.hpp>
+//
+#include <llfs/storage_simulation.hpp>
+
+namespace llfs {
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*explicit*/ SimulatedLogDeviceStorage::EphemeralState::EphemeralState(
+    std::shared_ptr<DurableState>&& durable_state) noexcept
+    : durable_state_{std::move(durable_state)}
+    , simulation_{this->durable_state_->simulation()}
+    , creation_step_{this->simulation_.current_step()}
+{
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::post_to_event_loop(
+    std::function<void(StatusOr<i32>)>&& handler)
+{
+  this->work_count_.fetch_add(1);
+
+  this->simulation_.post([this, handler = BATT_FORWARD(handler)]() mutable {
+    Status push_status = this->queue_.push([this, handler]() mutable {
+      BATT_FORWARD(handler)(StatusOr<i32>{0});
+    });
+
+    if (!push_status.ok()) {
+      this->work_count_.fetch_sub(1);
+      handler(push_status);
+    }
+  });
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::async_write_some_fixed(
+    i64 file_offset, const ConstBuffer& data, i32 /*buf_index*/,
+    std::function<void(StatusOr<i32>)>&& handler)
+{
+  if (this->closed_.load()) {
+    BATT_FORWARD(handler)(Status{batt::StatusCode::kClosed});
+    return;
+  }
+
+  auto* write_task = new batt::Task{
+      this->simulation_.task_scheduler().schedule_task(),
+      [this, file_offset, data, handler = BATT_FORWARD(handler)]() mutable {
+        Status status =
+            this->multi_block_iop<ConstBuffer, &DurableState::write_block>(file_offset, data);
+
+        if (status.ok()) {
+          BATT_FORWARD(handler)(StatusOr<i32>{static_cast<i32>(data.size())});
+        } else {
+          BATT_FORWARD(handler)(status);
+        }
+      },
+      batt::Task::DeferStart{true}};
+
+  write_task->call_when_done([write_task] {
+    delete write_task;
+  });
+
+  write_task->start();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::simulation_post(std::function<void()>&& fn)
+{
+  this->simulation_.post(std::move(fn));
+}
+
+}  //namespace llfs

--- a/src/llfs/simulated_log_device_storage.cpp
+++ b/src/llfs/simulated_log_device_storage.cpp
@@ -16,9 +16,98 @@
 
 namespace llfs {
 
+// Explicitly instantiate BasicIoRingLogDriver for the simulated LogDevice storage.
+//
 template class BasicIoRingLogDriver<BasicIoRingLogFlushOp, SimulatedLogDeviceStorage>;
+
+// BasicIoRingLogFlushOp is required by BasicIoRingLogDriver, so explicitly instantiate that too.
+//
 template class BasicIoRingLogFlushOp<
     BasicIoRingLogDriver<BasicIoRingLogFlushOp, SimulatedLogDeviceStorage>>;
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// class SimulatedLogDeviceStorage::DurableState
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::DurableState::crash_and_recover(u64 simulation_step) /*override*/
+{
+  batt::ScopedLock<Impl> locked{this->impl_};
+
+  locked->last_recovery_step_ = simulation_step;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status SimulatedLogDeviceStorage::DurableState::validate_args(i64 offset, usize size) noexcept
+{
+  if (offset % sizeof(AlignedBlock) != 0 || size != sizeof(AlignedBlock)) {
+    return batt::StatusCode::kInvalidArgument;
+  }
+  if (offset < this->config_.physical_offset) {
+    return batt::StatusCode::kOutOfRange;
+  }
+  if (offset + size > this->config_.physical_offset + this->config_.physical_size) {
+    return batt::StatusCode::kOutOfRange;
+  }
+  if (this->simulation_.inject_failure()) {
+    return batt::StatusCode::kInternal;
+  }
+
+  return OkStatus();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+template <typename BufferT, typename OpFn>
+Status SimulatedLogDeviceStorage::DurableState::block_op_impl(u64 creation_step, i64 offset,
+                                                              const BufferT& buffer, OpFn&& op_fn)
+{
+  BATT_REQUIRE_OK(this->validate_args(offset, buffer.size()));
+
+  batt::ScopedLock<Impl> locked{this->impl_};
+
+  if (creation_step < locked->last_recovery_step_) {
+    return batt::StatusCode::kClosed;
+  }
+
+  auto& p_block = locked->blocks_[offset];
+  BATT_FORWARD(op_fn)(p_block);
+
+  return batt::OkStatus();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status SimulatedLogDeviceStorage::DurableState::write_block(u64 creation_step, i64 offset,
+                                                            const ConstBuffer& buffer)
+{
+  return this->block_op_impl(creation_step, offset, buffer,
+                             [&buffer](std::unique_ptr<AlignedBlock>& p_block) {
+                               if (!p_block) {
+                                 p_block = std::make_unique<AlignedBlock>();
+                               }
+                               std::memcpy(p_block.get(), buffer.data(), buffer.size());
+                             });
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status SimulatedLogDeviceStorage::DurableState::read_block(u64 creation_step, i64 offset,
+                                                           const MutableBuffer& buffer)
+{
+  return this->block_op_impl(creation_step, offset, buffer,
+                             [&buffer](std::unique_ptr<AlignedBlock>& p_block) {
+                               if (!p_block) {
+                                 std::memset(buffer.data(), 0, buffer.size());
+                               } else {
+                                 std::memcpy(buffer.data(), p_block.get(), buffer.size());
+                               }
+                             });
+}
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// class SimulatedLogDeviceStorage::EphemeralState
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
@@ -32,21 +121,155 @@ template class BasicIoRingLogFlushOp<
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
+batt::TaskScheduler& SimulatedLogDeviceStorage::EphemeralState::get_task_scheduler() noexcept
+{
+  return this->simulation_.is_running() ? this->simulation_.task_scheduler()
+                                        : batt::Runtime::instance().default_scheduler();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status SimulatedLogDeviceStorage::EphemeralState::close()
+{
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::close()";
+
+  if (this->closed_.exchange(true)) {
+    return batt::StatusCode::kClosed;
+  }
+
+  return batt::OkStatus();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::on_work_started()
+{
+  const i32 old_value = this->work_count_.fetch_add(1);
+
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::on_work_started() " << old_value << " -> " << (old_value + 1);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::on_work_finished()
+{
+  const i32 old_value = this->work_count_.fetch_sub(1);
+
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::on_work_finished() " << old_value << " -> " << (old_value - 1);
+
+  if (old_value == 1) {
+    this->queue_.poke();
+  }
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status SimulatedLogDeviceStorage::EphemeralState::run_event_loop()
+{
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::run_event_loop() entered" << std::endl
+               << boost::stacktrace::stacktrace{};
+  for (;;) {
+    LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+                 << "EphemeralState::run_event_loop() top of loop:" << BATT_INSPECT(this->stopped_)
+                 << BATT_INSPECT(this->work_count_);
+    if (this->stopped_.load() || this->work_count_.load() == 0) {
+      break;
+    }
+
+    BATT_DEBUG_INFO(BATT_INSPECT(this->stopped_)
+                    << BATT_INSPECT(this->work_count_) << BATT_INSPECT(this->closed_));
+
+    LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+                 << "EphemeralState::run_event_loop() waiting for queue";
+    StatusOr<std::function<void()>> handler = this->queue_.await_next();
+    if (!handler.ok()) {
+      if (handler.status() == batt::StatusCode::kPoke) {
+        continue;
+      }
+
+      if (handler.status() == batt::StatusCode::kClosed) {
+        break;
+      }
+
+      return handler.status();
+    }
+
+    try {
+      (*handler)();
+    } catch (...) {
+      LLFS_LOG_WARNING() << "Simulation handler threw exception!";
+    }
+  }
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::run_event_loop() exiting";
+
+  return batt::OkStatus();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::reset_event_loop()
+{
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::reset_event_loop()" << BATT_INSPECT(this->stopped_);
+  this->stopped_.store(false);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EphemeralState::stop_event_loop()
+{
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::reset_event_loop()" << BATT_INSPECT(this->stopped_);
+  this->stopped_.store(true);
+  this->queue_.poke();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 void SimulatedLogDeviceStorage::EphemeralState::post_to_event_loop(
     std::function<void(StatusOr<i32>)>&& handler)
 {
-  this->work_count_.fetch_add(1);
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::post_to_event_loop(handler) entered"
+               << BATT_INSPECT(this->simulation_.is_running());
 
-  this->simulation_.post([this, handler = BATT_FORWARD(handler)]() mutable {
-    Status push_status = this->queue_.push([this, handler]() mutable {
-      BATT_FORWARD(handler)(StatusOr<i32>{0});
-    });
+  this->on_work_started();
 
-    if (!push_status.ok()) {
-      this->work_count_.fetch_sub(1);
-      handler(push_status);
-    }
-  });
+  auto runnable = [this, handler = BATT_FORWARD(handler)]() mutable {
+    LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+                 << "EphemeralState::post_to_event_loop(handler) invoked runnable";
+
+    this->queue_
+        .push([this, handler]() mutable {
+          auto on_scope_exit = batt::finally([&] {
+            this->on_work_finished();
+          });
+          BATT_FORWARD(handler)(StatusOr<i32>{0});
+        })
+        .IgnoreError();
+  };
+
+  if (this->simulation_.is_running()) {
+    this->simulation_.post(std::move(runnable));
+  } else {
+    runnable();
+  }
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status SimulatedLogDeviceStorage::EphemeralState::read_all(i64 offset, MutableBuffer buffer)
+{
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::read_all(" << BATT_INSPECT(offset) << ","
+               << BATT_INSPECT(buffer.size()) << ")";
+
+  return this->multi_block_iop<MutableBuffer, &DurableState::read_block>(offset, buffer);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -55,22 +278,43 @@ void SimulatedLogDeviceStorage::EphemeralState::async_write_some_fixed(
     i64 file_offset, const ConstBuffer& data, i32 /*buf_index*/,
     std::function<void(StatusOr<i32>)>&& handler)
 {
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphemeralState::async_write_some(offset=" << file_offset
+               << ", size=" << data.size() << ")";
+
   if (this->closed_.load()) {
     BATT_FORWARD(handler)(Status{batt::StatusCode::kClosed});
     return;
   }
 
-  auto* write_task = new batt::Task{
-      this->simulation_.task_scheduler().schedule_task(),
-      [this, file_offset, data, handler = BATT_FORWARD(handler)]() mutable {
-        Status status =
-            this->multi_block_iop<ConstBuffer, &DurableState::write_block>(file_offset, data);
+  this->on_work_started();
 
-        if (status.ok()) {
-          BATT_FORWARD(handler)(StatusOr<i32>{static_cast<i32>(data.size())});
-        } else {
-          BATT_FORWARD(handler)(status);
-        }
+  auto* write_task = new batt::Task{
+      this->get_task_scheduler().schedule_task(),
+      [shared_this = batt::shared_ptr_from(this), file_offset, data,
+       handler = BATT_FORWARD(handler)]() mutable {
+        auto* const this_ = shared_this.get();
+
+        // Write all blocks synchronously.
+        //
+        Status status =
+            this_->multi_block_iop<ConstBuffer, &DurableState::write_block>(file_offset, data);
+
+        auto result = [&] {
+          if (status.ok()) {
+            return StatusOr<i32>{static_cast<i32>(data.size())};
+          }
+          return StatusOr<i32>{status};
+        }();
+
+        this_->queue_
+            .push([handler, result, this_] {
+              auto on_scope_exit = batt::finally([this_] {
+                this_->on_work_finished();
+              });
+              handler(result);
+            })
+            .IgnoreError();
       },
       batt::Task::DeferStart{true}};
 
@@ -83,10 +327,92 @@ void SimulatedLogDeviceStorage::EphemeralState::async_write_some_fixed(
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
+template <typename BufferT,
+          Status (SimulatedLogDeviceStorage::DurableState::*Op)(u64, i64, const BufferT&)>
+Status SimulatedLogDeviceStorage::EphemeralState::multi_block_iop(i64 offset, BufferT buffer)
+{
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphmeralState::multi_block_iop(" << BATT_INSPECT(offset) << ","
+               << BATT_INSPECT(buffer.size())
+               << ") type=" << (std::is_same_v<BufferT, ConstBuffer> ? "write" : "read");
+
+  if (this->closed_.load()) {
+    return batt::StatusCode::kClosed;
+  }
+
+  std::vector<Status> block_status(buffer.size() / sizeof(AlignedBlock));
+  batt::Watch<usize> blocks_remaining(block_status.size());
+  std::atomic<usize> pin_count{block_status.size()};
+
+  if (buffer.size() != block_status.size() * sizeof(AlignedBlock)) {
+    return batt::StatusCode::kInvalidArgument;
+  }
+
+  usize i = 0;
+  while (buffer.size() > 0) {
+    LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+                 << "EphmeralState::multi_block_iop()" << BATT_INSPECT(offset) << BATT_INSPECT(i)
+                 << "/" << block_status.size();
+
+    this->simulation_post([this, i, offset, &block_status, &blocks_remaining, &pin_count,
+                           block_buffer = BufferT{buffer.data(), sizeof(AlignedBlock)}] {
+      LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+                   << "EphmeralState::multi_block_iop() - activated" << BATT_INSPECT(offset)
+                   << BATT_INSPECT(i);
+
+      auto on_scope_exit = batt::finally([&] {
+        blocks_remaining.fetch_sub(1);
+        pin_count.fetch_sub(1);
+      });
+
+      block_status[i] =
+          (this->durable_state_.get()->*Op)(this->creation_step_, offset, block_buffer);
+    });
+
+    offset += sizeof(AlignedBlock);
+    buffer += sizeof(AlignedBlock);
+    ++i;
+  }
+
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphmeralState::multi_block_iop() waiting for all ops to complete";
+
+  blocks_remaining.await_equal(0).IgnoreError();
+  BATT_CHECK_EQ(blocks_remaining.get_value(), 0u);
+  while (pin_count.load() != 0) {
+    batt::Task::yield();
+  }
+
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphmeralState::multi_block_iop() checking per-block statuses";
+
+  for (const Status& status : block_status) {
+    BATT_REQUIRE_OK(status);
+  }
+
+  LLFS_VLOG(1) << "(id=" << this->id_ << ")"
+               << "EphmeralState::multi_block_iop() success!";
+
+  return batt::OkStatus();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 void SimulatedLogDeviceStorage::EphemeralState::simulation_post(std::function<void()>&& fn)
 {
-  this->simulation_.post(std::move(fn));
+  if (this->simulation_.is_running()) {
+    this->simulation_.post(std::move(fn));
+  } else {
+    try {
+      std::move(fn)();
+    } catch (...) {
+      LLFS_LOG_WARNING() << "Simulation post fn threw exception!";
+    }
+  }
 }
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// class SimulatedLogDeviceStorage::RawBlockFileImpl
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
@@ -95,6 +421,99 @@ void SimulatedLogDeviceStorage::EphemeralState::simulation_post(std::function<vo
     : durable_state_{std::move(durable_state)}
     , creation_step_{this->durable_state_->simulation().current_step()}
 {
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+StatusOr<i64> SimulatedLogDeviceStorage::RawBlockFileImpl::write_some(
+    i64 offset, const ConstBuffer& buffer_arg) /*override*/
+{
+  ConstBuffer buffer = buffer_arg;
+  i64 n_written = 0;
+
+  while (buffer.size() > 0) {
+    BATT_REQUIRE_OK(this->durable_state_->write_block(
+        this->creation_step_, offset,
+        ConstBuffer{buffer.data(), std::min(buffer.size(), sizeof(AlignedBlock))}));
+    offset += sizeof(AlignedBlock);
+    buffer += sizeof(AlignedBlock);
+    n_written += sizeof(AlignedBlock);
+  }
+
+  return n_written;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+StatusOr<i64> SimulatedLogDeviceStorage::RawBlockFileImpl::read_some(
+    i64 offset, const MutableBuffer& buffer_arg) /*override*/
+{
+  MutableBuffer buffer = buffer_arg;
+  i64 n_read = 0;
+
+  while (buffer.size() > 0) {
+    BATT_REQUIRE_OK(this->durable_state_->read_block(
+        this->creation_step_, offset,
+        MutableBuffer{buffer.data(), std::min(buffer.size(), sizeof(AlignedBlock))}));
+    offset += sizeof(AlignedBlock);
+    buffer += sizeof(AlignedBlock);
+    n_read += sizeof(AlignedBlock);
+  }
+
+  return n_read;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+StatusOr<i64> SimulatedLogDeviceStorage::RawBlockFileImpl::get_size() /*override*/
+{
+  return Status{batt::StatusCode::kUnimplemented};
+}
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// class SimulatedLogDeviceStorage::EventLoopTask
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+/*explicit*/ SimulatedLogDeviceStorage::EventLoopTask::EventLoopTask(
+    SimulatedLogDeviceStorage& storage, std::string_view caller) noexcept
+    : storage_{storage}
+    , caller_{caller}
+    , task_{this->storage_.impl_->get_task_scheduler().schedule_task(),
+            [this] {
+              LLFS_VLOG(1) << "Entered simulated log storage event loop;"
+                           << BATT_INSPECT(this->caller_)
+                           << BATT_INSPECT(this->storage_.impl_->id());
+
+              this->storage_.impl_->run_event_loop().IgnoreError();
+
+              LLFS_VLOG(1) << "Leaving simulated log storage event loop;"
+                           << BATT_INSPECT(this->caller_)
+                           << BATT_INSPECT(this->storage_.impl_->id());
+            },
+            batt::to_string("SimulatedLogDeviceStorage::EventLoopTask(", caller, ")")}
+{
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+SimulatedLogDeviceStorage::EventLoopTask::~EventLoopTask() noexcept
+{
+  BATT_CHECK(this->join_called_);
+  BATT_CHECK(this->task_.is_done());
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SimulatedLogDeviceStorage::EventLoopTask::join()
+{
+  this->join_called_ = true;
+  this->task_.join();
+
+  LLFS_VLOG(1) << "EventLoopTask::join() exiting;"
+               << BATT_INSPECT(this->storage_.impl_->work_count())
+               << BATT_INSPECT(this->storage_.impl_->is_stopped())
+               << BATT_INSPECT(this->storage_.impl_->id());
 }
 
 }  //namespace llfs

--- a/src/llfs/simulated_log_device_storage.hpp
+++ b/src/llfs/simulated_log_device_storage.hpp
@@ -1,0 +1,341 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_SIMULATED_LOG_DEVICE_STORAGE_HPP
+#define LLFS_SIMULATED_LOG_DEVICE_STORAGE_HPP
+
+#include <llfs/config.hpp>
+//
+#include <llfs/packed_log_page_buffer.hpp>
+#include <llfs/simulated_storage_object.hpp>
+#include <llfs/status.hpp>
+
+#include <batteries/async/mutex.hpp>
+#include <batteries/async/queue.hpp>
+#include <batteries/async/watch.hpp>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+
+namespace llfs {
+
+class StorageSimulation;
+
+class SimulatedLogDeviceStorage
+{
+ public:
+  using AlignedBlock = PackedLogPageBuffer::AlignedUnit;
+
+  class DurableState : public SimulatedStorageObject
+  {
+   public:
+    struct Impl {
+      u64 last_recovery_step_{0};
+      std::unordered_map<i64, std::unique_ptr<AlignedBlock>> blocks_;
+    };
+
+    //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+    explicit DurableState(StorageSimulation& simulation) noexcept : simulation_{simulation}
+    {
+    }
+
+    //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+    StorageSimulation& simulation() noexcept
+    {
+      return this->simulation_;
+    }
+
+    /** \brief Simulates a process termination/restart by removing all non-flushed state.
+     */
+    void crash_and_recover(u64 simulation_step) override
+    {
+      batt::ScopedLock<Impl> locked{this->impl_};
+
+      locked->last_recovery_step_ = simulation_step;
+    }
+
+    //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+    Status write_block(u64 creation_step, i64 offset, const ConstBuffer& buffer)
+    {
+      if (offset % sizeof(AlignedBlock) != 0 || buffer.size() != sizeof(AlignedBlock)) {
+        return batt::StatusCode::kInvalidArgument;
+      }
+
+      batt::ScopedLock<Impl> locked{this->impl_};
+
+      if (creation_step < locked->last_recovery_step_) {
+        return batt::StatusCode::kClosed;
+      }
+
+      auto& p_block = locked->blocks_[offset];
+      if (!p_block) {
+        p_block = std::make_unique<AlignedBlock>();
+      }
+      std::memcpy(p_block.get(), buffer.data(), buffer.size());
+
+      return batt::OkStatus();
+    }
+
+    Status read_block(u64 creation_step, i64 offset, const MutableBuffer& buffer)
+    {
+      if (offset % sizeof(AlignedBlock) != 0 || buffer.size() != sizeof(AlignedBlock)) {
+        return batt::StatusCode::kInvalidArgument;
+      }
+
+      batt::ScopedLock<Impl> locked{this->impl_};
+
+      if (creation_step < locked->last_recovery_step_) {
+        return batt::StatusCode::kClosed;
+      }
+
+      auto& p_block = locked->blocks_[offset];
+      if (!p_block) {
+        return batt::StatusCode::kNotFound;
+      }
+      std::memcpy(buffer.data(), p_block.get(), buffer.size());
+
+      return batt::OkStatus();
+    }
+
+   private:
+    StorageSimulation& simulation_;
+    batt::Mutex<Impl> impl_;
+  };
+
+  class EphemeralState
+  {
+   public:
+    explicit EphemeralState(std::shared_ptr<DurableState>&& durable_state) noexcept;
+
+    //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+    Status close()
+    {
+      if (this->closed_.exchange(true)) {
+        return batt::StatusCode::kClosed;
+      }
+
+      return batt::OkStatus();
+    }
+
+    void on_work_started()
+    {
+      this->work_count_.fetch_add(1);
+    }
+
+    void on_work_finished()
+    {
+      if (this->work_count_.fetch_sub(1) == 1) {
+        this->queue_.poke();
+      }
+    }
+
+    Status run_event_loop()
+    {
+      for (;;) {
+        if (this->stopped_.load() || this->work_count_.load() == 0) {
+          break;
+        }
+
+        StatusOr<std::function<void()>> handler = this->queue_.await_next();
+        if (!handler.ok()) {
+          if (handler.status() == batt::StatusCode::kPoke) {
+            continue;
+          }
+
+          if (handler.status() == batt::StatusCode::kClosed) {
+            break;
+          }
+
+          return handler.status();
+        }
+
+        try {
+          (*handler)();
+        } catch (...) {
+          LLFS_LOG_WARNING() << "Simulation handler threw exception!";
+        }
+      }
+
+      return batt::OkStatus();
+    }
+
+    void reset_event_loop()
+    {
+      this->stopped_.store(false);
+    }
+
+    void post_to_event_loop(std::function<void(StatusOr<i32>)>&& handler);
+
+    void stop_event_loop()
+    {
+      this->stopped_.store(true);
+      this->queue_.poke();
+    }
+
+    Status read_all(i64 offset, MutableBuffer buffer)
+    {
+      return this->multi_block_iop<MutableBuffer, &DurableState::read_block>(offset, buffer);
+    }
+
+    void async_write_some_fixed(i64 file_offset, const ConstBuffer& data, i32 /*buf_index*/,
+                                std::function<void(StatusOr<i32>)>&& handler);
+
+    //+++++++++++-+-+--+----- --- -- -  -  -   -
+   private:
+    void simulation_post(std::function<void()>&& fn);
+
+    template <typename BufferT, Status (DurableState::*Op)(u64, i64, const BufferT&)>
+    Status multi_block_iop(i64 offset, BufferT buffer)
+    {
+      if (this->closed_.load()) {
+        return batt::StatusCode::kClosed;
+      }
+
+      std::vector<Status> block_status(buffer.size() / sizeof(AlignedBlock));
+      batt::Watch<usize> blocks_remaining(block_status.size());
+      std::atomic<usize> pin_count{block_status.size()};
+
+      if (buffer.size() != block_status.size() * sizeof(AlignedBlock)) {
+        return batt::StatusCode::kInvalidArgument;
+      }
+
+      usize i = 0;
+      while (buffer.size() > 0) {
+        this->simulation_post([this, i, offset, &block_status, &blocks_remaining, &pin_count,
+                               block_buffer = BufferT{buffer.data(), sizeof(AlignedBlock)}] {
+          auto on_scope_exit = batt::finally([&] {
+            blocks_remaining.fetch_sub(1);
+            pin_count.fetch_sub(1);
+          });
+
+          block_status[i] =
+              (this->durable_state_.get()->*Op)(this->creation_step_, offset, block_buffer);
+        });
+
+        offset += sizeof(AlignedBlock);
+        buffer += sizeof(AlignedBlock);
+        ++i;
+      }
+
+      BATT_CHECK_OK(blocks_remaining.await_equal(0));
+      while (pin_count.load() != 0) {
+        batt::Task::yield();
+      }
+
+      for (const Status& status : block_status) {
+        BATT_REQUIRE_OK(status);
+      }
+
+      return batt::OkStatus();
+    }
+
+    //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+    const std::shared_ptr<DurableState> durable_state_;
+
+    StorageSimulation& simulation_;
+
+    const u64 creation_step_;
+
+    std::atomic<i32> work_count_{0};
+
+    batt::Queue<std::function<void()>> queue_;
+
+    std::atomic<bool> closed_{false};
+
+    std::atomic<bool> stopped_{false};
+  };
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  explicit SimulatedLogDeviceStorage(std::shared_ptr<DurableState>&& durable_state) noexcept
+      : impl_{std::make_unique<EphemeralState>(std::move(durable_state))}
+  {
+  }
+
+  SimulatedLogDeviceStorage(const SimulatedLogDeviceStorage&) = delete;
+  SimulatedLogDeviceStorage& operator=(const SimulatedLogDeviceStorage&) = delete;
+
+  SimulatedLogDeviceStorage(SimulatedLogDeviceStorage&&) = default;
+  SimulatedLogDeviceStorage& operator=(SimulatedLogDeviceStorage&&) = default;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  Status register_fd()
+  {
+    return batt::OkStatus();
+  }
+
+  StatusOr<usize> register_buffers(batt::BoxedSeq<MutableBuffer>&&, bool = false) const noexcept
+  {
+    return {0};
+  }
+
+  Status close()
+  {
+    return this->impl_->close();
+  }
+
+  void on_work_started() const noexcept
+  {
+    this->impl_->on_work_started();
+  }
+
+  void on_work_finished() const noexcept
+  {
+    this->impl_->on_work_finished();
+  }
+
+  Status run_event_loop() const noexcept
+  {
+    return this->impl_->run_event_loop();
+  }
+
+  void reset_event_loop() const noexcept
+  {
+    this->impl_->reset_event_loop();
+  }
+
+  template <typename Handler = void(StatusOr<i32>)>
+  void post_to_event_loop(Handler&& handler) const noexcept
+  {
+    this->impl_->post_to_event_loop(BATT_FORWARD(handler));
+  }
+
+  void stop_event_loop() const noexcept
+  {
+    this->impl_->stop_event_loop();
+  }
+
+  Status read_all(i64 offset, MutableBuffer buffer)
+  {
+    return this->impl_->read_all(offset, buffer);
+  }
+
+  template <typename Handler = void(StatusOr<i32>)>
+  void async_write_some_fixed(i64 file_offset, const ConstBuffer& data, i32 buf_index,
+                              Handler&& handler)
+  {
+    this->impl_->async_write_some_fixed(file_offset, data, buf_index, BATT_FORWARD(handler));
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+ private:
+  std::unique_ptr<EphemeralState> impl_;
+};
+
+}  //namespace llfs
+
+#endif  // LLFS_SIMULATED_LOG_DEVICE_STORAGE_HPP

--- a/src/llfs/simulated_log_device_storage.hpp
+++ b/src/llfs/simulated_log_device_storage.hpp
@@ -167,10 +167,10 @@ class SimulatedLogDeviceStorage
 
     void stop_event_loop();
 
-    Status read_all(i64 offset, MutableBuffer buffer);
+    Status read_all(i64 offset, const MutableBuffer& buffer);
 
-    void async_write_some_fixed(i64 file_offset, const ConstBuffer& data, i32 /*buf_index*/,
-                                std::function<void(StatusOr<i32>)>&& handler);
+    void async_write_some(i64 file_offset, const ConstBuffer& data,
+                          std::function<void(StatusOr<i32>)>&& handler);
 
     i32 work_count() const noexcept
     {
@@ -318,11 +318,14 @@ class SimulatedLogDeviceStorage
     return this->impl_->read_all(offset, buffer);
   }
 
+  // The buf_index arg here isn't used by the simulated impl, but it is needed by the other type
+  // used to instantiate IoRingLogDriver, DefaultIoRingLogDeviceStorage.
+  //
   template <typename Handler = void(StatusOr<i32>)>
-  void async_write_some_fixed(i64 file_offset, const ConstBuffer& data, i32 buf_index,
+  void async_write_some_fixed(i64 file_offset, const ConstBuffer& data, i32 /*buf_index*/,
                               Handler&& handler)
   {
-    this->impl_->async_write_some_fixed(file_offset, data, buf_index, BATT_FORWARD(handler));
+    this->impl_->async_write_some(file_offset, data, BATT_FORWARD(handler));
   }
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/slot_reader.cpp
+++ b/src/llfs/slot_reader.cpp
@@ -105,7 +105,7 @@ StatusOr<SlotParse> SlotReader::parse_next(batt::WaitForResource wait_for_data)
     const usize bytes_available_before = data_reader.bytes_available();
 
     if (bytes_available_before != 0) {
-      BATT_CHECK_NE(*data_reader.unread_begin(), 0u)
+      BATT_CHECK_NE((int)(*data_reader.unread_begin()), 0)
           << BATT_INSPECT(bytes_available_before) << BATT_INSPECT(current_slot)
           << BATT_INSPECT(data.size()) << BATT_INSPECT(current_slot + data.size())
           << BATT_INSPECT(this->slots_parsed_count_);

--- a/src/llfs/slot_writer.cpp
+++ b/src/llfs/slot_writer.cpp
@@ -98,7 +98,8 @@ StatusOr<MutableBuffer> SlotWriter::WriterLock::prepare(usize slot_payload_size,
 //
 SlotRange SlotWriter::WriterLock::defer_commit() noexcept
 {
-  const slot_offset_type slot_lower_bound = (*this->writer_lock_)->slot_offset();
+  const slot_offset_type slot_lower_bound =
+      (*this->writer_lock_)->slot_offset() + this->deferred_commit_size_;
   const slot_offset_type slot_upper_bound = slot_lower_bound + this->prepare_size_;
 
   this->deferred_commit_size_ += this->prepare_size_;

--- a/src/llfs/slot_writer.cpp
+++ b/src/llfs/slot_writer.cpp
@@ -61,7 +61,8 @@ void SlotWriter::halt()
 //
 /*static*/ Slice<const u8> SlotWriter::WriterLock::begin_atomic_range_token() noexcept
 {
-  const static std::array<u8, 3> token_ = {0b10000000, 0b10000000, 0b00000000};
+  const static std::array<u8, Self::kBeginAtomicRangeTokenSize> token_ = {0b10000000, 0b10000000,
+                                                                          0b00000000};
   return as_const_slice(token_);
 }
 
@@ -69,7 +70,7 @@ void SlotWriter::halt()
 //
 /*static*/ Slice<const u8> SlotWriter::WriterLock::end_atomic_range_token() noexcept
 {
-  const static std::array<u8, 2> token_ = {0b10000000, 0b00000000};
+  const static std::array<u8, Self::kEndAtomicRangeTokenSize> token_ = {0b10000000, 0b00000000};
   return as_const_slice(token_);
 }
 

--- a/src/llfs/slot_writer.cpp
+++ b/src/llfs/slot_writer.cpp
@@ -170,7 +170,8 @@ SlotRange SlotWriter::WriterLock::defer_commit() noexcept
 //
 StatusOr<SlotRange> SlotWriter::WriterLock::commit(batt::Grant& caller_grant) noexcept
 {
-  this->defer_commit();
+  this->deferred_commit_size_ += this->prepare_size_;
+  this->prepare_size_ = 0;
 
   const slot_offset_type slot_lower_bound = (*this->writer_lock_)->slot_offset();
 

--- a/src/llfs/slot_writer.cpp
+++ b/src/llfs/slot_writer.cpp
@@ -59,104 +59,112 @@ void SlotWriter::halt()
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-auto SlotWriter::prepare(batt::Grant& caller_grant, usize slot_body_size) -> StatusOr<Append>
-{
-  BATT_CHECK_NE(slot_body_size, 0);
-
-  const usize slot_header_size = packed_sizeof_varint(slot_body_size);
-  const usize slot_size = slot_header_size + slot_body_size;
-
-  StatusOr<batt::Grant> slot_grant = caller_grant.spend(slot_size);
-  if (slot_grant.status() == batt::StatusCode::kGrantUnavailable) {
-    return ::llfs::make_status(StatusCode::kSlotGrantTooSmall);
-  }
-  BATT_REQUIRE_OK(slot_grant);
-
-  batt::Mutex<LogDevice::Writer*>::Lock writer_lock = this->log_writer_.lock();
-  StatusOr<MutableBuffer> slot_buffer = (*writer_lock)->prepare(slot_size, /*head_room=*/0);
-  BATT_REQUIRE_OK(slot_buffer);
-
-  return {Append{
-      this,
-      std::move(writer_lock),
-      std::move(*slot_grant),
-      *slot_buffer,
-      slot_body_size,
-  }};
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-SlotWriter::Append::Append(SlotWriter* that, batt::Mutex<LogDevice::Writer*>::Lock writer_lock,
-                           batt::Grant&& slot_grant, const MutableBuffer& slot_buffer,
-                           usize slot_body_size) noexcept
-    : that_{that}
-    , writer_lock_{std::move(writer_lock)}
-    , slot_grant_{std::move(slot_grant)}
-    , cancelled_{false}
-    , committed_{false}
-    , slot_lower_bound_{(*this->writer_lock_)->slot_offset()}
-    , packer_{slot_buffer}
+/*explicit*/ SlotWriter::WriterLock::WriterLock(SlotWriter& slot_writer) noexcept
+    : slot_writer_{slot_writer}
+    , writer_lock_{this->slot_writer_.log_writer_}  // Lock the LogDevice::Writer mutex
 {
   BATT_CHECK_NOT_NULLPTR(*this->writer_lock_);
-  BATT_CHECK_EQ(this->slot_grant_.get_issuer(), &this->that_->pool_);
-  BATT_CHECK_EQ(this->packer_.buffer_size(), this->slot_grant_.size());
-  BATT_CHECK_NOT_NULLPTR(this->packer_.pack_varint(slot_body_size));
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-SlotWriter::Append::~Append() noexcept
+StatusOr<MutableBuffer> SlotWriter::WriterLock::prepare(usize slot_payload_size,
+                                                        const batt::Grant& caller_grant) noexcept
 {
-  this->cancel();
-}
+  BATT_CHECK_NE(slot_payload_size, 0);
 
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-StatusOr<SlotRange> SlotWriter::Append::commit()
-{
-  if (this->cancelled_) {
-    return {batt::StatusCode::kCancelled};
+  const usize slot_header_size = packed_sizeof_varint(slot_payload_size);
+  const usize slot_size = slot_header_size + slot_payload_size;
+  const usize prepare_size = this->deferred_commit_size_ + slot_size;
+
+  if (caller_grant.size() < prepare_size) {
+    return ::llfs::make_status(StatusCode::kSlotGrantTooSmall);
   }
 
-  BATT_CHECK(!this->committed_);
-  this->committed_ = true;
-  LLFS_VLOG(1) << "LogDevice::Writer::commit(" << this->packer_.buffer_size() << ")";
+  BATT_ASSIGN_OK_RESULT(MutableBuffer buffer,
+                        (*this->writer_lock_)->prepare(prepare_size, /*head_room=*/0));
 
-  StatusOr<slot_offset_type> commit_slot_upper_bound =
-      (*this->writer_lock_)->commit(this->packer_.buffer_size());
+  this->prepare_size_ = slot_size;
 
-  BATT_REQUIRE_OK(commit_slot_upper_bound);
+  buffer += this->deferred_commit_size_;
 
-  LLFS_VLOG(1) << (void*)this << " commit succeeded; new upper_bound= " << *commit_slot_upper_bound
-               << " == " << (*this->writer_lock_)->slot_offset();
+  Optional<MutableBuffer> payload_buffer = pack_varint_to(buffer, slot_payload_size);
+  BATT_CHECK(payload_buffer);
 
-  // Grow the in-use grant by the amount written.
-  //
-  BATT_CHECK_EQ(this->that_->in_use_.get_issuer(), this->slot_grant_.get_issuer());
-  this->that_->in_use_.subsume(std::move(this->slot_grant_));
+  return {*payload_buffer};
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+SlotRange SlotWriter::WriterLock::defer_commit() noexcept
+{
+  const slot_offset_type slot_lower_bound = (*this->writer_lock_)->slot_offset();
+  const slot_offset_type slot_upper_bound = slot_lower_bound + this->prepare_size_;
+
+  this->deferred_commit_size_ += this->prepare_size_;
+  this->prepare_size_ = 0;
 
   return SlotRange{
-      .lower_bound = this->slot_lower_bound_,
-      .upper_bound = *commit_slot_upper_bound,
+      .lower_bound = slot_lower_bound,
+      .upper_bound = slot_upper_bound,
   };
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-void SlotWriter::Append::cancel()
+StatusOr<SlotRange> SlotWriter::WriterLock::commit(batt::Grant& caller_grant) noexcept
 {
-  const auto set_cancelled = batt::finally([&] {
-    this->cancelled_ = true;
-  });
+  this->defer_commit();
 
-  if (this->writer_lock_) {
-    if (!this->cancelled_ && !this->committed_) {
-      (*this->writer_lock_)->commit(0).IgnoreError();
-    }
-    this->slot_grant_.spend_all();
-    this->writer_lock_.release();
+  const slot_offset_type slot_lower_bound = (*this->writer_lock_)->slot_offset();
+
+  if (this->deferred_commit_size_ == 0) {
+    return SlotRange{
+        .lower_bound = slot_lower_bound,
+        .upper_bound = slot_lower_bound,
+    };
   }
+
+  StatusOr<batt::Grant> commit_grant = caller_grant.spend(this->deferred_commit_size_);
+  if (commit_grant.status() == batt::StatusCode::kGrantUnavailable) {
+    return ::llfs::make_status(StatusCode::kSlotGrantTooSmall);
+  }
+  BATT_REQUIRE_OK(commit_grant);
+
+  StatusOr<slot_offset_type> slot_upper_bound =
+      (*this->writer_lock_)->commit(this->deferred_commit_size_);
+
+  BATT_REQUIRE_OK(slot_upper_bound);
+
+  LLFS_VLOG(1) << (void*)this << " commit succeeded; new upper_bound= " << *slot_upper_bound
+               << " == " << (*this->writer_lock_)->slot_offset();
+
+  // Grow the in-use grant by the amount written.
+  //
+  BATT_CHECK_EQ(this->slot_writer_.in_use_.get_issuer(), commit_grant->get_issuer());
+  this->slot_writer_.in_use_.subsume(std::move(*commit_grant));
+
+  this->deferred_commit_size_ = 0;
+
+  return SlotRange{
+      .lower_bound = slot_lower_bound,
+      .upper_bound = *slot_upper_bound,
+  };
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SlotWriter::WriterLock::cancel_prepare() noexcept
+{
+  this->prepare_size_ = 0;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void SlotWriter::WriterLock::cancel_all() noexcept
+{
+  this->cancel_prepare();
+  this->deferred_commit_size_ = 0;
 }
 
 }  // namespace llfs

--- a/src/llfs/slot_writer.hpp
+++ b/src/llfs/slot_writer.hpp
@@ -136,6 +136,9 @@ class SlotWriter::WriterLock
  public:
   using Self = WriterLock;
 
+  static constexpr usize kBeginAtomicRangeTokenSize = 3;
+  static constexpr usize kEndAtomicRangeTokenSize = 2;
+
   static Slice<const u8> begin_atomic_range_token() noexcept;
   static Slice<const u8> end_atomic_range_token() noexcept;
 

--- a/src/llfs/slot_writer.hpp
+++ b/src/llfs/slot_writer.hpp
@@ -304,6 +304,19 @@ class TypedSlotWriter<PackedVariant<Ts...>> : public SlotWriter
       };
     }
 
+    /** \brief Like typed_append, but erases type information from the returned value.
+     */
+    template <typename T, typename PackedT = PackedTypeFor<T>>
+    StatusOr<SlotRange> append(const batt::Grant& caller_grant, T&& payload)
+    {
+      StatusOr<SlotParseWithPayload<const PackedTypeFor<T>*>> packed =
+          this->typed_append(caller_grant, BATT_FORWARD(payload));
+
+      BATT_REQUIRE_OK(packed);
+
+      return {packed->slot.offset};
+    }
+
     /** \brief Atomically commits all slots appended previously by `this` via typed_append.
      */
     template <typename PostCommitFn = NullPostCommitFn>

--- a/src/llfs/slot_writer.hpp
+++ b/src/llfs/slot_writer.hpp
@@ -206,6 +206,10 @@ class SlotWriter::WriterLock
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
  private:
+  /** \brief Appends the specified byte range to the prepared data.  `token` is just a raw byte
+   * sequence, not a full slot.  This function is used to implement the `begin_atomic_range` and
+   * `end_atomic_range` tokens.
+   */
   Status append_token_impl(const Slice<const u8>& token, const batt::Grant& caller_grant) noexcept;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/slot_writer.hpp
+++ b/src/llfs/slot_writer.hpp
@@ -139,7 +139,7 @@ class SlotWriter::WriterLock
   static Slice<const u8> begin_atomic_range_token() noexcept;
   static Slice<const u8> end_atomic_range_token() noexcept;
 
-  //----- --- -- -  -  -   -
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   /** \brief Acquires an exclusive lock on writing to the log managed by `slot_writer`, preparing
    * to write new slot data.  This lock is released when the WriterLock object goes out of scope.
@@ -154,7 +154,7 @@ class SlotWriter::WriterLock
    */
   WriterLock& operator=(const WriterLock&) = delete;
 
-  //----- --- -- -  -  -   -
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   /** \brief Appends special token to the log to indicate the start of a sequence of slots that
    * must commit/recover atomically.
@@ -201,11 +201,11 @@ class SlotWriter::WriterLock
    */
   void cancel_all() noexcept;
 
-  //----- --- -- -  -  -   -
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
  private:
   Status append_token_impl(const Slice<const u8>& token, const batt::Grant& caller_grant) noexcept;
 
-  //----- --- -- -  -  -   -
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   /** \brief The SlotWriter object passed in at construction time.
    */

--- a/src/llfs/slot_writer.hpp
+++ b/src/llfs/slot_writer.hpp
@@ -14,6 +14,7 @@
 
 #include <llfs/data_layout.hpp>
 #include <llfs/data_packer.hpp>
+#include <llfs/optional.hpp>
 #include <llfs/slot_parse.hpp>
 
 #include <batteries/async/grant.hpp>
@@ -30,7 +31,83 @@ class SlotWriter
  public:
   class Append;
 
+  class WriterLock
+  {
+   public:
+    /** \brief Acquires an exclusive lock on writing to the log managed by `slot_writer`, preparing
+     * to write new slot data.  This lock is released when the WriterLock object goes out of scope.
+     */
+    explicit WriterLock(SlotWriter& slot_writer) noexcept;
+
+    /** \brief WriterLock is not copyable.
+     */
+    WriterLock(const WriterLock&) = delete;
+
+    /** \brief WriterLock is not copyable.
+     */
+    WriterLock& operator=(const WriterLock&) = delete;
+
+    //----- --- -- -  -  -   -
+
+    /** \brief Verifies that the passed grant can accomodate a new slot with the passed payload size
+     * (in addition to any currently deferred slots), then allocates space in the log and writes a
+     * header for the new slot, returning a mutable buffer for _just_ the payload portion.
+     */
+    StatusOr<MutableBuffer> prepare(usize slot_payload_size,
+                                    const batt::Grant& caller_grant) noexcept;
+
+    /** \brief Defers the currently prepared slot for later commit.
+     *
+     * Future calls to prepare will return a memory segment after the deferred commit slots.
+     */
+    SlotRange defer_commit() noexcept;
+
+    /** \brief Commits the current prepared slot and any deferred commit slots to the log.
+     *
+     * Transfers the size of the committed data from `caller_grant` to the SlotWriter's in_use_
+     * grant.
+     *
+     * \return the log slot range of the committed data.
+     */
+    StatusOr<SlotRange> commit(batt::Grant& caller_grant) noexcept;
+
+    /** \brief Reverts the effect of the most recent call to prepare after the most recent call to
+     * defer_commit or commit.
+     */
+    void cancel_prepare() noexcept;
+
+    /** \brief Equivalent to this->cancel_prepare() plus clearing out all deferred commits.  Rolls
+     * back everything since the most recent call to this->commit().
+     */
+    void cancel_all() noexcept;
+
+    //----- --- -- -  -  -   -
+   private:
+    /** \brief The SlotWriter object passed in at construction time.
+     */
+    SlotWriter& slot_writer_;
+
+    /** \brief Lock on the SlotWriter's LogDevice::Writer.
+     */
+    batt::ScopedLock<LogDevice::Writer*> writer_lock_;
+
+    /** \brief The size (bytes) of the most recently prepared slot buffer (allocated via
+     * this->prepare).  This size includes the varint slot header (the payload size), so it is
+     * always larger than the `slot_payload_size` arg passed to `this->prepare()`.
+     */
+    usize prepare_size_ = 0;
+
+    /** \brief The size (bytes) of all slots that have been fully packed and are ready for commit
+     * the next time `this->commit()` is called.
+     */
+    usize deferred_commit_size_ = 0;
+  };
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
   explicit SlotWriter(LogDevice& log_device) noexcept;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   usize log_size() const
   {
@@ -101,10 +178,6 @@ class SlotWriter
     return this->log_device_.sync(mode, event);
   }
 
-  // Prepare space in the log to append a slot.
-  //
-  StatusOr<Append> prepare(batt::Grant& grant, usize slot_body_size);
-
  private:
   LogDevice& log_device_;
 
@@ -127,67 +200,6 @@ class SlotWriter
 };
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
-
-class SlotWriter::Append
-{
- public:
-  explicit Append(SlotWriter* that, batt::Mutex<LogDevice::Writer*>::Lock writer_lock,
-                  batt::Grant&& slot_grant, const MutableBuffer& slot_buffer,
-                  usize slot_body_size) noexcept;
-
-  Append(const Append&) = delete;
-  Append& operator=(const Append&) = delete;
-
-  BATT_SUPPRESS_IF_CLANG("-Wdefaulted-function-deleted")
-  //
-  Append(Append&&) = default;
-  Append& operator=(Append&&) = default;
-  //
-  BATT_UNSUPPRESS_IF_CLANG()
-
-  ~Append() noexcept;
-
-  slot_offset_type slot_lower_bound() const
-  {
-    return this->slot_lower_bound_;
-  }
-
-  DataPacker& packer()
-  {
-    return this->packer_;
-  }
-
-  StatusOr<SlotRange> commit();
-
-  void cancel();
-
- private:
-  SlotWriter* that_;
-
-  // To pack the data into the log, we need exclusive access.
-  //
-  batt::Mutex<LogDevice::Writer*>::Lock writer_lock_;
-
-  // The slot_grant will be destroyed when we return, releasing its count back to the pool.
-  //
-  batt::Grant slot_grant_;
-
-  // Was this append cancelled?
-  //
-  bool cancelled_;
-
-  // Was this append committed?
-  //
-  bool committed_;
-
-  // The beginning offset at which this append will occur if committed.
-  //
-  slot_offset_type slot_lower_bound_;
-
-  // Exposed to the caller to serialize the contents of the slot.
-  //
-  DataPacker packer_;
-};
 
 inline constexpr usize packed_sizeof_slot_with_payload_size(usize payload_size)
 {
@@ -225,6 +237,87 @@ class TypedSlotWriter<PackedVariant<Ts...>> : public SlotWriter
     }
   };
 
+  /** \brief An append operation of one or more slots.
+   */
+  class MultiAppend
+  {
+   public:
+    /** \brief Initialize a MultiAppend operation using the passed TypedSlotWriter.
+     *
+     * This will obtain a lock on the slot writer's LogDevice::Writer mutex.
+     */
+    explicit MultiAppend(TypedSlotWriter& slot_writer) noexcept : writer_lock_{slot_writer}
+    {
+    }
+
+    MultiAppend(const MultiAppend&) = delete;
+    MultiAppend& operator=(const MultiAppend&) = delete;
+
+    //----- --- -- -  -  -   -
+
+    /** \brief Packs a single slot into the log device buffer.  Does not commit the slot; all slots
+     * are committed atomically when this->finalize() is called.
+     */
+    template <typename T, typename PackedT = PackedTypeFor<T>>
+    StatusOr<SlotParseWithPayload<const PackedT*>> typed_append(const batt::Grant& caller_grant,
+                                                                T&& payload)
+    {
+      // Calculate packed size of payload.
+      //
+      const usize slot_payload_size = sizeof(PackedVariant<Ts...>) + packed_sizeof(payload);
+
+      // Allocate log buffer space and write the slot header (varint).
+      //
+      BATT_ASSIGN_OK_RESULT(MutableBuffer payload_buffer,
+                            this->writer_lock_.prepare(slot_payload_size, caller_grant));
+
+      // Pack the payload.
+      //
+      DataPacker packer{payload_buffer};
+
+      PackedVariant<Ts...>* const variant_head =
+          packer.pack_record(batt::StaticType<PackedVariant<Ts...>>{});
+
+      if (!variant_head) {
+        return ::llfs::make_status(StatusCode::kFailedToPackSlotVarHead);
+      }
+
+      variant_head->init(batt::StaticType<PackedT>{});
+
+      if (!pack_object(BATT_FORWARD(payload), &packer)) {
+        return ::llfs::make_status(StatusCode::kFailedToPackSlotVarTail);
+      }
+
+      // Add the packed slot to the deferred commit segment.
+      //
+      SlotRange slot_range = this->writer_lock_.defer_commit();
+      auto* slot_payload_start = reinterpret_cast<const char*>(variant_head);
+
+      return SlotParseWithPayload<const PackedT*>{
+          .slot =
+              SlotParse{
+                  .offset = slot_range,
+                  .body = std::string_view{slot_payload_start, slot_payload_size},
+                  .total_grant_spent = slot_payload_size,
+              },
+          .payload = variant_head->as(batt::StaticType<PackedT>{}),
+      };
+    }
+
+    /** \brief Atomically commits all slots appended previously by `this` via typed_append.
+     */
+    template <typename PostCommitFn = NullPostCommitFn>
+    StatusOr<SlotRange> finalize(batt::Grant& caller_grant,
+                                 PostCommitFn&& post_commit_fn = {}) noexcept
+    {
+      return post_commit_fn(this->writer_lock_.commit(caller_grant));
+    }
+
+    //----- --- -- -  -  -   -
+   private:
+    SlotWriter::WriterLock writer_lock_;
+  };
+
   /** \brief Appends `payload` to the log using the passed `caller_grant`.
    *
    * \param caller_grant Must be at least as large as packed_sizeof(payload)
@@ -242,44 +335,17 @@ class TypedSlotWriter<PackedVariant<Ts...>> : public SlotWriter
                                                               T&& payload,
                                                               PostCommitFn&& post_commit_fn = {})
   {
-    const usize slot_body_size = sizeof(PackedVariant<Ts...>) + packed_sizeof(payload);
-    BATT_CHECK_NE(slot_body_size, 0u);
-
-    // Lock the writer in SlotWriter::prepare.
+    // Appending a single slot is treated as a degenerate case of a MultiAppend.
     //
-    StatusOr<Append> op = this->SlotWriter::prepare(caller_grant, slot_body_size);
-    BATT_REQUIRE_OK(op);
+    MultiAppend op{*this};
 
-    // Do allocation for the buffer to write the variant-ID.
-    //
-    PackedVariant<Ts...>* variant_head =
-        op->packer().pack_record(batt::StaticType<PackedVariant<Ts...>>{});
-    if (!variant_head) {
-      return ::llfs::make_status(StatusCode::kFailedToPackSlotVarHead);
-    }
+    StatusOr<SlotParseWithPayload<const PackedT*>> result =
+        op.typed_append(caller_grant, BATT_FORWARD(payload));
 
-    // Get variant-ID ('which') for this entry.
-    //
-    variant_head->init(batt::StaticType<PackedT>{});
+    BATT_REQUIRE_OK(result);
+    BATT_REQUIRE_OK(op.finalize(caller_grant, post_commit_fn));
 
-    if (!pack_object(BATT_FORWARD(payload), &(op->packer()))) {
-      return ::llfs::make_status(StatusCode::kFailedToPackSlotVarTail);
-    }
-
-    StatusOr<SlotRange> slot_range = post_commit_fn(op->commit());
-    BATT_REQUIRE_OK(slot_range);
-
-    auto* slot_body_start = reinterpret_cast<const char*>(variant_head);
-
-    return SlotParseWithPayload<const PackedT*>{
-        .slot =
-            SlotParse{
-                .offset = *slot_range,
-                .body = std::string_view{slot_body_start, slot_body_size},
-                .total_grant_spent = slot_body_size,
-            },
-        .payload = variant_head->as(batt::StaticType<PackedT>{}),
-    };
+    return result;
   }
 
   template <typename T, typename PostCommitFn = NullPostCommitFn>

--- a/src/llfs/slot_writer.test.cpp
+++ b/src/llfs/slot_writer.test.cpp
@@ -1,0 +1,45 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/slot_writer.hpp>
+//
+#include <llfs/slot_writer.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <llfs/varint.hpp>
+
+namespace {
+
+using namespace llfs::int_types;
+
+TEST(SlotWriterTest, BeginEndAtomicRangeTokens)
+{
+  llfs::Slice<const u8> begin_token = llfs::SlotWriter::WriterLock::begin_atomic_range_token();
+  llfs::Slice<const u8> end_token = llfs::SlotWriter::WriterLock::end_atomic_range_token();
+
+  EXPECT_EQ(begin_token.size(), llfs::SlotWriter::WriterLock::kBeginAtomicRangeTokenSize);
+  EXPECT_EQ(end_token.size(), llfs::SlotWriter::WriterLock::kEndAtomicRangeTokenSize);
+  EXPECT_NE(begin_token.size(), end_token.size());
+  EXPECT_GT(begin_token.size(), 1u);
+  EXPECT_GT(end_token.size(), 1u);
+
+  const auto verify_parses_as_zero = [](const llfs::Slice<const u8>& token) {
+    auto [parsed_n, end_of_parse] = llfs::unpack_varint_from(token.begin(), token.end());
+
+    ASSERT_TRUE(parsed_n);
+    EXPECT_EQ(*parsed_n, 0u);
+    EXPECT_EQ(end_of_parse, token.end());
+  };
+
+  verify_parses_as_zero(begin_token);
+  verify_parses_as_zero(end_token);
+}
+
+}  // namespace

--- a/src/llfs/storage_simulation.cpp
+++ b/src/llfs/storage_simulation.cpp
@@ -9,6 +9,12 @@
 #include <llfs/storage_simulation.hpp>
 //
 
+#include <llfs/basic_ring_buffer_log_device.hpp>
+#include <llfs/confirm.hpp>
+#include <llfs/ioring_log_driver.hpp>
+#include <llfs/ioring_log_driver_options.hpp>
+#include <llfs/ioring_log_flush_op.hpp>
+#include <llfs/ioring_log_initializer.hpp>
 #include <llfs/simulated_log_device.hpp>
 #include <llfs/simulated_log_device_impl.hpp>
 #include <llfs/simulated_page_device.hpp>
@@ -167,30 +173,80 @@ void StorageSimulation::handle_events()
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
+SimulatedLogDeviceStorage StorageSimulation::get_log_device_storage(const std::string& name,
+                                                                    Optional<u64> capacity)
+{
+  auto iter = this->log_storage_.find(name);
+
+  // If we didn't find the named storage object, then create it.
+  //
+  if (iter == this->log_storage_.end()) {
+    BATT_CHECK(capacity.has_value());
+
+    auto config = IoRingLogConfig::from_logical_size(*capacity);
+    auto durable_state = std::make_shared<SimulatedLogDeviceStorage::DurableState>(*this, config);
+
+    Status init_status =
+        initialize_ioring_log_device(*std::make_unique<SimulatedLogDeviceStorage::RawBlockFileImpl>(
+                                         batt::make_copy(durable_state)),
+                                     config, ConfirmThisWillEraseAllMyData::kYes);
+
+    BATT_CHECK_OK(init_status);
+
+    iter = this->log_storage_.emplace(name, std::move(durable_state)).first;
+  }
+
+  BATT_CHECK_NE(iter, this->log_storage_.end());
+  BATT_CHECK_NOT_NULLPTR(iter->second);
+
+  return SimulatedLogDeviceStorage{batt::make_copy(iter->second)};
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 std::unique_ptr<LogDevice> StorageSimulation::get_log_device(const std::string& name,
                                                              Optional<u64> capacity)
 {
-  auto iter = this->log_devices_.find(name);
+  if (this->low_level_log_devices_) {
+    SimulatedLogDeviceStorage storage = this->get_log_device_storage(name, capacity);
+    IoRingLogConfig config = storage.config();
+    auto options = IoRingLogDriverOptions::with_default_values();
+    options.name = name;
 
-  // If we didn't find the named device, then create it.
-  //
-  if (iter == this->log_devices_.end()) {
-    BATT_CHECK(capacity)
-        << "Must specify capacity if creating a simulated log device for the first time!";
+    using DriverT = BasicIoRingLogDriver<BasicIoRingLogFlushOp, SimulatedLogDeviceStorage>;
+    using LogDeviceT = BasicRingBufferLogDevice<DriverT>;
 
-    iter = this->log_devices_
-               .emplace(name, std::make_shared<SimulatedLogDevice::Impl>(*this, name, *capacity))
-               .first;
+    auto log_device =
+        std::make_unique<LogDeviceT>(RingBuffer::TempFile{.byte_size = config.logical_size},
+                                     this->task_scheduler(), std::move(storage), config, options);
+
+    BATT_CHECK_OK(log_device->open());
+
+    return log_device;
+
+  } else {
+    auto iter = this->log_devices_.find(name);
+
+    // If we didn't find the named device, then create it.
+    //
+    if (iter == this->log_devices_.end()) {
+      BATT_CHECK(capacity)
+          << "Must specify capacity if creating a simulated log device for the first time!";
+
+      iter = this->log_devices_
+                 .emplace(name, std::make_shared<SimulatedLogDevice::Impl>(*this, name, *capacity))
+                 .first;
+    }
+
+    // At this point we should have a valid entry.
+    //
+    BATT_CHECK_NE(iter, this->log_devices_.end());
+    BATT_CHECK_NOT_NULLPTR(iter->second);
+
+    LLFS_LOG_SIM_EVENT() << "creating SimulatedLogDevice " << batt::c_str_literal(name);
+
+    return std::make_unique<SimulatedLogDevice>(batt::make_copy(iter->second));
   }
-
-  // At this point we should have a valid entry.
-  //
-  BATT_CHECK_NE(iter, this->log_devices_.end());
-  BATT_CHECK_NOT_NULLPTR(iter->second);
-
-  LLFS_LOG_SIM_EVENT() << "creating SimulatedLogDevice " << batt::c_str_literal(name);
-
-  return std::make_unique<SimulatedLogDevice>(batt::make_copy(iter->second));
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/storage_simulation.hpp
+++ b/src/llfs/storage_simulation.hpp
@@ -107,7 +107,7 @@ class StorageSimulation
   /** \brief Forces the PageCache to be shut down; this will stop all background tasks associated
    * with the PageAllocators.
    */
-  void close_cache() noexcept;
+  void close_cache(bool main_fn_done = false) noexcept;
 
   /** \brief Returns a reference to a TaskScheduler that should be used for all Tasks involved in
    * the simulation.
@@ -164,6 +164,13 @@ class StorageSimulation
   void log_event(Args&&... args) const noexcept
   {
     LLFS_LOG_SIM_EVENT() << batt::to_string(BATT_FORWARD(args)...);
+  }
+
+  /** \brief Returns true iff the simulation is running.
+   */
+  bool is_running() const noexcept
+  {
+    return this->is_running_.load();
   }
 
   /** \brief Launches the "driver" (main) simulation task.  This is the entry point to the
@@ -259,7 +266,7 @@ class StorageSimulation
   /** \brief Step the simulation forward repeatedly until there are no pending handlers that can
    * run.
    */
-  void handle_events();
+  void handle_events(bool main_fn_done);
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -327,7 +334,11 @@ class StorageSimulation
 
   // Are we in low-level LogDevice simulation mode?
   //
-  bool low_level_log_devices_ = false;
+  bool low_level_log_devices_ = true;
+
+  // Set to true when we are inside the main simulation loop.
+  //
+  std::atomic<bool> is_running_{false};
 };
 
 }  //namespace llfs

--- a/src/llfs/storage_simulation.hpp
+++ b/src/llfs/storage_simulation.hpp
@@ -12,6 +12,8 @@
 
 #include <llfs/config.hpp>
 //
+#include <llfs/testing/test_config.hpp>
+
 #include <llfs/int_types.hpp>
 #include <llfs/log_device.hpp>
 #include <llfs/optional.hpp>
@@ -270,6 +272,10 @@ class StorageSimulation
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
+  // Reads test configuration from the environment.
+  //
+  testing::TestConfig test_config_;
+
   // Used to select event orderings, operations into which to inject failures, etc.
   //
   batt::StateMachineEntropySource entropy_source_;
@@ -334,7 +340,7 @@ class StorageSimulation
 
   // Are we in low-level LogDevice simulation mode?
   //
-  bool low_level_log_devices_ = true;
+  bool low_level_log_devices_ = this->test_config_.low_level_log_device_sim();
 
   // Set to true when we are inside the main simulation loop.
   //

--- a/src/llfs/testing/test_config.cpp
+++ b/src/llfs/testing/test_config.cpp
@@ -1,0 +1,87 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/testing/test_config.hpp>
+//
+
+#include <batteries/env.hpp>
+
+namespace llfs {
+namespace testing {
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+TestConfig::TestConfig() noexcept
+{
+  this->extra_testing_ =                          //
+      batt::getenv_as<int>("LLFS_EXTRA_TESTING")  //
+          .value_or(0);
+
+  this->low_level_log_device_sim_ =                          //
+      batt::getenv_as<int>("LLFS_LOW_LEVEL_LOG_DEVICE_SIM")  //
+          .value_or(1);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+bool TestConfig::extra_testing() const noexcept
+{
+  return this->extra_testing_;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+bool TestConfig::low_level_log_device_sim() const noexcept
+{
+  return this->low_level_log_device_sim_;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+const std::filesystem::path& TestConfig::project_dir() noexcept
+{
+  if (this->project_dir_.empty()) {
+    this->project_dir_ = []() {
+      const char* project_dir_env = std::getenv("PROJECT_DIR");
+      if (project_dir_env) {
+        return std::filesystem::path{project_dir_env};
+      }
+
+      std::filesystem::path file_path{__FILE__};
+      if (std::filesystem::exists(file_path)) {
+        std::filesystem::path testing_dir_path = file_path.parent_path();
+        if (std::filesystem::exists(testing_dir_path)) {
+          std::filesystem::path src_llfs_dir_path = testing_dir_path.parent_path();
+          if (std::filesystem::exists(src_llfs_dir_path)) {
+            std::filesystem::path src_dir_path = src_llfs_dir_path.parent_path();
+            if (std::filesystem::exists(src_dir_path)) {
+              std::filesystem::path project_dir_path = src_dir_path.parent_path();
+              if (std::filesystem::exists(project_dir_path)) {
+                return project_dir_path;
+              }
+            }
+          }
+        }
+      }
+
+      BATT_PANIC() << "Could not find project root; make sure PROJECT_DIR is set!";
+      BATT_UNREACHABLE();
+    }();
+  }
+  return this->project_dir_;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+std::filesystem::path TestConfig::data_file_path(std::string_view file_rel_path) noexcept
+{
+  return this->project_dir() / "testdata" / file_rel_path;
+}
+
+}  //namespace testing
+}  //namespace llfs

--- a/src/llfs/testing/test_config.hpp
+++ b/src/llfs/testing/test_config.hpp
@@ -1,0 +1,71 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_TESTING_TEST_CONFIG_HPP
+#define LLFS_TESTING_TEST_CONFIG_HPP
+
+#include <llfs/config.hpp>
+//
+
+#include <filesystem>
+
+namespace llfs {
+namespace testing {
+
+/** \brief Captures testing-related settings from the environment and presents them to test code
+ * with a simple API.
+ */
+class TestConfig
+{
+ public:
+  /** \brief Construct a TestConfig from the current environment.
+   */
+  TestConfig() noexcept;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  /** \brief Returns whether tests should take extra time to run very thorough tests on more cases.
+   *
+   * Controlled by env var `LLFS_EXTRA_TESTING`.
+   */
+  bool extra_testing() const noexcept;
+
+  /** \brief Returns whether StorageSimulations should use low-level LogDevice simulation
+   * (default=true).
+   *
+   * Controlled by env var `LLFS_LOW_LEVEL_LOG_DEVICE_SIM`.
+   */
+  bool low_level_log_device_sim() const noexcept;
+
+  /** \brief Determines the current repository root directory.
+   *
+   * By default, this is derived from `__FILE__` and built-in assumptions about the directory layout
+   * of the project.  It can be overridden via the environment variable `PROJECT_DIR`.
+   */
+  const std::filesystem::path& project_dir() noexcept;
+
+  /** \brief Returns the path to the named data file.
+   *
+   * Test data files are located in <PROJECT_DIR>/testdata/.
+   */
+  std::filesystem::path data_file_path(std::string_view file_rel_path) noexcept;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+ private:
+  bool extra_testing_;
+
+  bool low_level_log_device_sim_;
+
+  std::filesystem::path project_dir_;
+};
+
+}  //namespace testing
+}  //namespace llfs
+
+#endif  // LLFS_TESTING_TEST_CONFIG_HPP

--- a/src/llfs/testing/util.cpp
+++ b/src/llfs/testing/util.cpp
@@ -9,6 +9,8 @@
 #include <llfs/testing/util.hpp>
 //
 
+#include <llfs/testing/test_config.hpp>
+
 namespace llfs {
 namespace testing {
 
@@ -16,41 +18,18 @@ namespace testing {
 //
 const std::filesystem::path& get_project_dir()
 {
-  static const std::filesystem::path cached = []() {
-    const char* project_dir_env = std::getenv("PROJECT_DIR");
-    if (project_dir_env) {
-      return std::filesystem::path{project_dir_env};
-    }
+  TestConfig test_config;
 
-    std::filesystem::path file_path{__FILE__};
-    if (std::filesystem::exists(file_path)) {
-      std::filesystem::path testing_dir_path = file_path.parent_path();
-      if (std::filesystem::exists(testing_dir_path)) {
-        std::filesystem::path src_llfs_dir_path = testing_dir_path.parent_path();
-        if (std::filesystem::exists(src_llfs_dir_path)) {
-          std::filesystem::path src_dir_path = src_llfs_dir_path.parent_path();
-          if (std::filesystem::exists(src_dir_path)) {
-            std::filesystem::path project_dir_path = src_dir_path.parent_path();
-            if (std::filesystem::exists(project_dir_path)) {
-              return project_dir_path;
-            }
-          }
-        }
-      }
-    }
-
-    BATT_PANIC() << "Could not find project root; make sure PROJECT_DIR is set!";
-    BATT_UNREACHABLE();
-  }();
-
-  return cached;
+  return test_config.project_dir();
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 std::filesystem::path get_test_data_file_path(std::string_view file_rel_path)
 {
-  return get_project_dir() / "testdata" / file_rel_path;
+  TestConfig test_config;
+
+  return test_config.data_file_path(file_rel_path);
 }
 
 }  //namespace testing

--- a/src/llfs/trie.test.cpp
+++ b/src/llfs/trie.test.cpp
@@ -13,6 +13,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <llfs/testing/test_config.hpp>
 #include <llfs/testing/util.hpp>
 
 #include <llfs/data_packer.hpp>
@@ -115,7 +116,9 @@ struct PackedSSTableWrapper {
 
 TEST(Trie, Test)
 {
-  const bool extra_testing = batt::getenv_as<int>("LLFS_EXTRA_TESTING").value_or(0);
+  llfs::testing::TestConfig test_config;
+
+  const bool extra_testing = test_config.extra_testing();
 
   auto words = load_words();
 
@@ -369,7 +372,9 @@ inline bool operator<(const Rec& l, const Rec& r)
 
 TEST(Trie, VEBLayoutTest)
 {
-  const bool extra_testing = batt::getenv_as<int>("LLFS_EXTRA_TESTING").value_or(0);
+  llfs::testing::TestConfig test_config;
+
+  const bool extra_testing = test_config.extra_testing();
 
   std::cerr << "depth, avg(BFS), avg(vEB), avg(RND),";
   for (usize i = 0; i < 32; ++i) {

--- a/src/llfs/varint.test.cpp
+++ b/src/llfs/varint.test.cpp
@@ -164,13 +164,21 @@ TEST(VarIntTest, BufferApi)
 //
 TEST(VarIntTest, ExtraBytes)
 {
-  std::array<u8, 2> packed = {0b10000000, 0b00000000};
+  std::array<u8, 1> packed1 = {0b00000000};
+  std::array<u8, 2> packed2 = {0b10000000, 0b00000000};
+  std::array<u8, 3> packed3 = {0b10000000, 0b10000000, 0b00000000};
 
-  auto [n, parse_end] = unpack_varint_from(packed.data(), packed.data() + packed.size());
+  auto verify = [](const auto& packed) {
+    auto [n, parse_end] = unpack_varint_from(packed.data(), packed.data() + packed.size());
 
-  ASSERT_TRUE(n);
-  EXPECT_EQ(*n, 0u);
-  EXPECT_EQ((void*)parse_end, (void*)(&packed[2]));
+    ASSERT_TRUE(n);
+    EXPECT_EQ(*n, 0u);
+    EXPECT_EQ((void*)parse_end, (void*)(&packed[packed.size()]));
+  };
+
+  ASSERT_NO_FATAL_FAILURE(verify(packed1));
+  ASSERT_NO_FATAL_FAILURE(verify(packed2));
+  ASSERT_NO_FATAL_FAILURE(verify(packed3));
 }
 
 }  // namespace

--- a/src/llfs/varint.test.cpp
+++ b/src/llfs/varint.test.cpp
@@ -26,8 +26,11 @@ using namespace llfs::int_types;
 
 using llfs::ConstBuffer;
 using llfs::MutableBuffer;
+using llfs::None;
 using llfs::Optional;
+using llfs::pack_varint_to;
 using llfs::packed_sizeof_varint;
+using llfs::unpack_varint_from;
 
 // Verify the edge-case boundaries of packed varint size (i.e., the precise integer values where the
 // packed size of a varint changes).
@@ -82,6 +85,77 @@ TEST(VarIntTest, RandomValues)
     }
     min_value = max_value + 1;
     max_value = ((max_value + 1) << 7) - 1;
+  }
+}
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+TEST(VarIntTest, BufferApi)
+{
+  const u64 small_num = 7;
+  const u64 large_num = 0xfedcba9876543210ull;
+
+  constexpr usize small_num_size = 1;
+  constexpr usize large_num_size = 10;
+
+  ASSERT_EQ(packed_sizeof_varint(small_num), small_num_size);
+  ASSERT_EQ(packed_sizeof_varint(large_num), large_num_size);
+
+  std::array<char, small_num_size> small_buf;
+  std::array<char, large_num_size> large_buf;
+
+  EXPECT_FALSE(pack_varint_to(MutableBuffer{small_buf.data(), small_buf.size()}, large_num));
+  EXPECT_FALSE(pack_varint_to(MutableBuffer{large_buf.data(), large_buf.size() - 1}, large_num));
+
+  Optional<MutableBuffer> packed;
+
+  packed = None;
+  packed = pack_varint_to(MutableBuffer{small_buf.data(), small_buf.size()}, small_num);
+
+  ASSERT_TRUE(packed);
+  EXPECT_EQ((void*)packed->data(), (void*)(small_buf.data() + small_buf.size()));
+  EXPECT_EQ(packed->size(), 0u);
+
+  packed = None;
+  packed = pack_varint_to(MutableBuffer{large_buf.data(), large_buf.size()}, large_num);
+
+  ASSERT_TRUE(packed);
+  EXPECT_EQ((void*)packed->data(), (void*)(large_buf.data() + large_buf.size()));
+  EXPECT_EQ(packed->size(), 0u);
+
+  {
+    auto src = ConstBuffer{small_buf.data(), small_buf.size()};
+    Optional<u64> unpacked_small_num = unpack_varint_from(&src);
+
+    ASSERT_TRUE(unpacked_small_num);
+    EXPECT_EQ(*unpacked_small_num, small_num);
+
+    EXPECT_EQ((void*)src.data(), (void*)(small_buf.data() + small_buf.size()));
+    EXPECT_EQ(src.size(), 0u);
+
+    auto [n, rest] = unpack_varint_from(ConstBuffer{small_buf.data(), small_buf.size()});
+
+    ASSERT_TRUE(n);
+    EXPECT_EQ(*n, small_num);
+    EXPECT_EQ(rest.size(), 0u);
+    EXPECT_EQ((void*)rest.data(), (void*)(small_buf.data() + small_buf.size()));
+  }
+  {
+    auto src = ConstBuffer{large_buf.data(), large_buf.size()};
+    Optional<u64> unpacked_large_num = unpack_varint_from(&src);
+
+    ASSERT_TRUE(unpacked_large_num);
+    EXPECT_EQ(*unpacked_large_num, large_num);
+
+    EXPECT_EQ((void*)src.data(), (void*)(large_buf.data() + large_buf.size()));
+    EXPECT_EQ(src.size(), 0u);
+
+    auto [n, rest] = unpack_varint_from(ConstBuffer{large_buf.data(), large_buf.size()});
+
+    ASSERT_TRUE(n);
+    EXPECT_EQ(*n, large_num);
+    EXPECT_EQ(rest.size(), 0u);
+    EXPECT_EQ((void*)rest.data(), (void*)(large_buf.data() + large_buf.size()));
   }
 }
 

--- a/src/llfs/varint.test.cpp
+++ b/src/llfs/varint.test.cpp
@@ -159,4 +159,18 @@ TEST(VarIntTest, BufferApi)
   }
 }
 
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// Test that we accept longer-than-necessary encodings of integers.
+//
+TEST(VarIntTest, ExtraBytes)
+{
+  std::array<u8, 2> packed = {0b10000000, 0b00000000};
+
+  auto [n, parse_end] = unpack_varint_from(packed.data(), packed.data() + packed.size());
+
+  ASSERT_TRUE(n);
+  EXPECT_EQ(*n, 0u);
+  EXPECT_EQ((void*)parse_end, (void*)(&packed[2]));
+}
+
 }  // namespace

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -194,7 +194,6 @@ u64 Volume::calculate_grant_size(const AppendableJob& appendable) const
           StatusOr<slot_offset_type> sync_slot =
               arena.allocator().attach_user(uuid, /*user_slot=*/next_available_slot_offset);
 
-          BATT_UNTESTED_COND(!sync_slot.ok());
           BATT_REQUIRE_OK(sync_slot);
 
           Status sync_status = arena.allocator().sync(*sync_slot);

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -572,7 +572,10 @@ StatusOr<SlotRange> Volume::append(AppendableJob&& appendable, batt::Grant& gran
 
     const auto grant_size_after_prepare = grant.size();
 
-    BATT_CHECK_EQ(prepared_job_size, grant_size_before_prepare - grant_size_after_prepare);
+    if (prepare_slot.ok()) {
+      BATT_CHECK_EQ(prepared_job_size, grant_size_before_prepare - grant_size_after_prepare)
+          << BATT_INSPECT(prepare_slot.status()) << BATT_INSPECT(grant_size_before_prepare);
+    }
 
     if (sequencer) {
       if (!prepare_slot.ok()) {

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -394,7 +394,7 @@ void Volume::halt()
   this->slot_writer_->halt();
   this->trim_control_->halt();
   this->trimmer_->halt();
-  this->root_log_->close().IgnoreError();
+  this->root_log_->halt();
   if (this->recycler_) {
     this->recycler_->halt();
   }
@@ -408,6 +408,7 @@ void Volume::join()
     this->trimmer_task_->join();
     this->trimmer_task_ = None;
   }
+  this->root_log_->join();
   if (this->recycler_) {
     this->recycler_->join();
   }

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -45,13 +45,17 @@ struct VolumeRecoverParams {
 };
 
 class VolumeJobRecoveryVisitor;
+class VolumeMultiAppend;
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //
 class Volume
 {
  public:
+  friend class VolumeMultiAppend;
   friend class VolumeReader;
+
+  using MultiAppend = VolumeMultiAppend;
 
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -349,3 +353,4 @@ class Volume
 #endif  // LLFS_VOLUME_HPP
 
 #include <llfs/volume.ipp>
+#include <llfs/volume_multi_append.hpp>

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -1431,7 +1431,7 @@ TEST_F(VolumeSimTest, RecoverySimulation)
       batt::getenv_as<u32>("LLFS_VOLUME_SIM_SEED").value_or(987654321);
 
   static const u32 kNumSeeds =  //
-      batt::getenv_as<u32>("LLFS_VOLUME_SIM_COUNT").value_or(2500);
+      batt::getenv_as<u32>("LLFS_VOLUME_SIM_COUNT").value_or(4096);
 
   static const u32 kCpuPin =  //
       batt::getenv_as<u32>("LLFS_VOLUME_SIM_CPU").value_or(0);
@@ -1506,6 +1506,8 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
                              llfs::PageGraphNodeView::page_reader());
 
     const auto main_task_fn = [&] {
+      LLFS_VLOG(1) << "entered main;" << BATT_INSPECT(seed);
+
       // Create the simulated Volume.
       //
       {
@@ -1519,6 +1521,8 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
         ASSERT_TRUE(recovered_volume.ok()) << recovered_volume.status();
 
         llfs::Volume& volume = **recovered_volume;
+
+        LLFS_VLOG(1) << "recovered volume";
 
         // Test plan:
         //  1. Concurrently, on `this->pages_per_device` different tasks:
@@ -1571,9 +1575,13 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
               /*name=*/batt::to_string("TestCommitTask", task_i)));
         }
 
+        LLFS_VLOG(1) << "starting tasks...";
+
         for (auto& p_task : tasks) {
           p_task->start();
         }
+
+        LLFS_VLOG(1) << "joining tasks...";
 
         for (auto& p_task : tasks) {
           p_task->join();
@@ -1585,6 +1593,8 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
         //
         constexpr i32 kExpectedRefCount = 2;
 
+        LLFS_VLOG(1) << "checking ref counts...";
+
         for (llfs::PageCache::PageDeviceEntry* entry :
              sim.cache()->devices_with_page_size(1 * kKiB)) {
           BATT_CHECK_NOT_NULLPTR(entry);
@@ -1594,8 +1604,11 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
           break;
         }
 
+        LLFS_VLOG(1) << "volume.halt()";
         volume.halt();
+        LLFS_VLOG(1) << "volume.join()";
         volume.join();
+        LLFS_VLOG(1) << "done!";
       }
     };
 
@@ -1655,15 +1668,22 @@ void VolumeSimTest::run_recovery_sim(u32 seed)
                            llfs::PageGraphNodeView::page_reader());
 
   const auto main_task_fn = [&] {
+    sim.set_inject_failures_mode(false);
+
+    LLFS_VLOG(1) << "Entered main task;" << BATT_INSPECT(seed) << BATT_INSPECT(sim.is_running());
+
     // Create the simulated Volume.
     //
     {
+      LLFS_VLOG(1) << "Creating simulated volume";
       batt::StatusOr<std::unique_ptr<llfs::Volume>> recovered_volume = sim.get_volume(
           "TestVolume", /*slot_visitor_fn=*/
           [](auto&&...) {
             return batt::OkStatus();
           },
           /*root_log_capacity=*/64 * kKiB);
+
+      LLFS_VLOG(1) << "volume recovery status=" << recovered_volume.status();
 
       ASSERT_TRUE(recovered_volume.ok()) << recovered_volume.status();
 
@@ -1683,13 +1703,18 @@ void VolumeSimTest::run_recovery_sim(u32 seed)
 
       // Simulate a full crash and recovery.
       //
+      LLFS_VLOG(1) << "Before crash_and_recover()";
       sim.crash_and_recover();
+      LLFS_VLOG(1) << "After crash_and_recover(); Before volume.halt()";
 
       // Terminate the volume.
       //
       volume.halt();
+      LLFS_VLOG(1) << "After volume.halt(); Before volume.join()";
       volume.join();
+      LLFS_VLOG(1) << "After volume.join()";
     }
+    LLFS_VLOG(1) << "First crash_and_recover()" << BATT_INSPECT(seed);
     EXPECT_TRUE(state.first_page_id.is_valid()) << BATT_INSPECT(state.seed);
 
     // Recover system state, post-crash.
@@ -1706,6 +1731,8 @@ void VolumeSimTest::run_recovery_sim(u32 seed)
       ASSERT_NO_FATAL_FAILURE(
           this->verify_post_recovery_expectations(state, sim, **recovered_volume));
     }
+
+    LLFS_VLOG(1) << "Sim run finished;" << BATT_INSPECT(seed);
   };
 
   sim.run_main_task(main_task_fn);

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <llfs/testing/fake_log_device.hpp>
+#include <llfs/testing/test_config.hpp>
 
 #include <llfs/memory_log_device.hpp>
 #include <llfs/memory_page_cache.hpp>
@@ -1427,11 +1428,14 @@ class VolumeSimTest : public ::testing::Test
 //
 TEST_F(VolumeSimTest, RecoverySimulation)
 {
+  static const llfs::testing::TestConfig test_config;
+
   static const u32 kInitialSeed =  //
       batt::getenv_as<u32>("LLFS_VOLUME_SIM_SEED").value_or(987654321);
 
   static const u32 kNumSeeds =  //
-      batt::getenv_as<u32>("LLFS_VOLUME_SIM_COUNT").value_or(4096);
+      batt::getenv_as<u32>("LLFS_VOLUME_SIM_COUNT")
+          .value_or(test_config.extra_testing() ? 65536 : 4096);
 
   static const u32 kCpuPin =  //
       batt::getenv_as<u32>("LLFS_VOLUME_SIM_CPU").value_or(0);

--- a/src/llfs/volume_multi_append.hpp
+++ b/src/llfs/volume_multi_append.hpp
@@ -14,18 +14,50 @@
 #error This file must be included from <llfs/volume.hpp>!
 #endif
 
+#include <llfs/slot_writer.hpp>
+
 namespace llfs {
 
+/** \brief An atomic, multiple slot append operation for a Volume.
+ *
+ * Unlike regular sequential appends, VolumeMultiAppend offers the following guarantees:
+ *
+ *  - All slots in the multi-append will appear sequentially with no interposed slots (from other
+ *    writers/threads)
+ *  - Only a single call will be made to the underlying LogDevice::Writer to commit the data
+ *  - On crash/recovery, either all of the slots in the multi-append will be visible, or none
+ */
 class VolumeMultiAppend
 {
  public:
+  /** \brief Returns the size grant required for a multi-append, given the total size of the grants
+   * needed for each slot.
+   */
+  static constexpr u64 calculate_grant_size(u64 slots_total_size) noexcept
+  {
+    return slots_total_size + SlotWriter::WriterLock::kBeginAtomicRangeTokenSize +
+           SlotWriter::WriterLock::kEndAtomicRangeTokenSize;
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  /** \brief Locks the volume's slot writer and initiates an atomic multi-slot append operation.
+   */
   explicit VolumeMultiAppend(Volume& volume) noexcept : op_{*volume.slot_writer_}
   {
   }
 
+  /** \brief VolumeMultiAppend is not copy-constructible.
+   */
   VolumeMultiAppend(const VolumeMultiAppend&) = delete;
+
+  /** \brief VolumeMultiAppend is not copy-assignable.
+   */
   VolumeMultiAppend& operator=(const VolumeMultiAppend&) = delete;
 
+  /** \brief Destroys the object; panics if neither of this->commit() nor this->cancel() have been
+   * invoked.
+   */
   ~VolumeMultiAppend() noexcept
   {
     BATT_CHECK(this->closed_);
@@ -33,22 +65,21 @@ class VolumeMultiAppend
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
-  u64 calculate_grant_size(u64 slots_total_size) const noexcept
-  {
-    return slots_total_size + (/*begin_atomic_range token size=*/3) +
-           (/*end_atomic_range token size=*/2);
-  }
-
+  /** \brief Returns true iff the multi-append operation is still accepting new slots.  Calling
+   * this->commit or this->cancel the first time will cause the status of the operation to go from
+   * "open" to "closed" (not open).
+   */
   bool is_open() const noexcept
   {
     return !this->closed_;
   }
 
-  bool is_closed() const noexcept
-  {
-    return this->closed_;
-  }
-
+  /** \brief Adds a single slot (the packed representation of T) to the end of the multi-append. The
+   * passed grant must be large enough to cover the *entire* multi-append, including the current
+   * payload and all payloads previously passed to append.
+   *
+   * \return the slot offset interval of the appended data
+   */
   template <typename T>
   StatusOr<SlotRange> append(const T& payload, const batt::Grant& grant) noexcept
   {
@@ -64,11 +95,22 @@ class VolumeMultiAppend
     return this->op_.append(grant, packed_obj_as_raw);
   }
 
+  /** \brief Adds a single slot (raw bytes) to the multi-append.
+   */
   StatusOr<SlotRange> append(const std::string_view& payload, const batt::Grant& grant)
   {
     return this->append(pack_as_raw(payload), grant);
   }
 
+  /** \brief Attempts to commit all slots that have been added to the multi-append, consuming part
+   * or all of the passed grant.
+   *
+   * This operation may fail due to insufficient grant or I/O errors in the underlying LogDevice
+   * (even though the data is flushed from memory to storage asychronously; this means an I/O error
+   * reported here was likely encountered while flushing previous data).
+   *
+   * \return the entire committed slot interval for the slots in the multi-append
+   */
   StatusOr<SlotRange> commit(batt::Grant& grant) noexcept
   {
     BATT_CHECK(!this->closed_);
@@ -84,6 +126,11 @@ class VolumeMultiAppend
     return result;
   }
 
+  /** \brief Abandons the multi-append without modifying the Volume root log.
+   *
+   * Note: does not release the writer lock for the volume; this object must be destroyed to release
+   * the lock.
+   */
   void cancel() noexcept
   {
     BATT_CHECK(!this->closed_);
@@ -91,8 +138,17 @@ class VolumeMultiAppend
   }
 
  private:
+  // Implements the actual log appending.
+  //
   TypedSlotWriter<VolumeEventVariant>::MultiAppend op_;
+
+  // true iff no call append has yet been made; used to determine when we should write a begin
+  // atomic range token to the log.
+  //
   bool first_ = true;
+
+  // true iff commit or cancel has been called.
+  //
   bool closed_ = false;
 };
 

--- a/src/llfs/volume_multi_append.hpp
+++ b/src/llfs/volume_multi_append.hpp
@@ -1,0 +1,71 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_VOLUME_MULTI_APPEND_HPP
+#define LLFS_VOLUME_MULTI_APPEND_HPP
+
+#ifndef LLFS_VOLUME_HPP
+#error This file must be included from <llfs/volume.hpp>!
+#endif
+
+namespace llfs {
+
+class VolumeMultiAppend
+{
+ public:
+  explicit VolumeMultiAppend(Volume& volume) noexcept : op_{*volume.slot_writer_}
+  {
+  }
+
+  VolumeMultiAppend(const VolumeMultiAppend&) = delete;
+  VolumeMultiAppend& operator=(const VolumeMultiAppend&) = delete;
+
+  ~VolumeMultiAppend() noexcept
+  {
+    BATT_CHECK(this->completed_);
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  template <typename T>
+  StatusOr<SlotRange> append(const T& payload, const batt::Grant& grant) noexcept
+  {
+    BATT_CHECK(!this->completed_);
+
+    llfs::PackObjectAsRawData<const T&> packed_obj_as_raw{payload};
+
+    return this->op_.append(grant, packed_obj_as_raw);
+  }
+
+  StatusOr<SlotRange> append(const std::string_view& payload, const batt::Grant& grant)
+  {
+    return this->append(pack_as_raw(payload), grant);
+  }
+
+  StatusOr<SlotRange> commit(batt::Grant& grant) noexcept
+  {
+    BATT_CHECK(!this->completed_);
+    this->completed_ = true;
+    return this->op_.finalize(grant);
+  }
+
+  void cancel() noexcept
+  {
+    BATT_CHECK(!this->completed_);
+    this->completed_ = true;
+  }
+
+ private:
+  TypedSlotWriter<VolumeEventVariant>::MultiAppend op_;
+  bool completed_ = false;
+};
+
+}  //namespace llfs
+
+#endif  // LLFS_VOLUME_MULTI_APPEND_HPP

--- a/src/llfs/volume_multi_append.test.cpp
+++ b/src/llfs/volume_multi_append.test.cpp
@@ -110,7 +110,7 @@ TEST(VolumeMultiAppendTest, SimTest)
               // space in the log to add `s`.
               //
               LLFS_VLOG(1) << "Append error" << BATT_INSPECT(grant.size())
-                           << BATT_INSPECT(op->is_closed());
+                           << BATT_INSPECT(op->is_open());
               break;
             }
 

--- a/src/llfs/volume_multi_append.test.cpp
+++ b/src/llfs/volume_multi_append.test.cpp
@@ -1,0 +1,140 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/volume.hpp>
+//
+#include <llfs/volume.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <llfs/storage_simulation.hpp>
+
+#include <random>
+
+namespace {
+
+using namespace llfs::int_types;
+using namespace llfs::constants;
+
+using llfs::StatusOr;
+
+TEST(VolumeMultiAppendTest_DISABLED, SimTest)
+{
+  for (u32 seed = 0; seed < 100; ++seed) {
+    for (usize n_before_crash = 1; n_before_crash < 20; ++n_before_crash) {
+      LLFS_LOG_INFO() << BATT_INSPECT(seed);
+      std::mt19937 rng{seed};
+
+      llfs::StorageSimulation sim{batt::StateMachineEntropySource{
+          /*entropy_fn=*/[&rng](usize min_value, usize max_value) -> usize {
+            std::uniform_int_distribution<usize> pick_value{min_value, max_value};
+            return pick_value(rng);
+          }}};
+
+      sim.run_main_task([&] {
+        //+++++++++++-+-+--+----- --- -- -  -  -   -
+        {
+          StatusOr<std::unique_ptr<llfs::Volume>> recovered_volume = sim.get_volume(
+              "TestVolume", /*slot_visitor_fn=*/
+              [](auto&&...) {
+                return batt::OkStatus();
+              },
+              /*root_log_capacity=*/64 * kKiB);
+
+          ASSERT_TRUE(recovered_volume.ok()) << recovered_volume.status();
+
+          llfs::Volume& volume = **recovered_volume;
+
+          batt::Grant grant = BATT_OK_RESULT_OR_PANIC(
+              volume.reserve(volume.available_to_reserve(), batt::WaitForResource::kFalse));
+
+          sim.set_inject_failures_mode(true);
+
+          batt::Optional<llfs::VolumeMultiAppend> op;
+          usize pos_in_batch = 0;
+          usize batch_size = 1;
+
+          for (usize i = 0; i < n_before_crash; ++i) {
+            if (!op) {
+              op.emplace(volume);
+            }
+
+            batt::Task::yield();
+
+            std::string_view s = (pos_in_batch + 1 < batch_size) ? "a" : "b";
+
+            if (!op->append(s, grant).ok()) {
+              LLFS_LOG_INFO() << "Append error";
+              op->cancel();
+              break;
+            }
+
+            ++pos_in_batch;
+            if (pos_in_batch == batch_size) {
+              ++batch_size;
+              pos_in_batch = 0;
+              if (!op->commit(grant).ok()) {
+                LLFS_LOG_INFO() << "Commit error";
+                break;
+              }
+              op = batt::None;
+            }
+          }
+
+          if (op) {
+            op->cancel();
+            op = batt::None;
+          }
+        }
+
+        sim.set_inject_failures_mode(false);
+        sim.crash_and_recover();
+
+        //+++++++++++-+-+--+----- --- -- -  -  -   -
+        {
+          std::string last_slot;
+          usize slots_found = 0;
+          i32 last_run = -1;
+          i32 run_length = 0;
+
+          StatusOr<std::unique_ptr<llfs::Volume>> recovered_volume = sim.get_volume(
+              "TestVolume", /*slot_visitor_fn=*/
+              [&](const llfs::SlotParse& slot, std::string_view user_data) {
+                ++slots_found;
+                last_slot = user_data;
+
+                LLFS_LOG_INFO() << BATT_INSPECT(slot.offset) << BATT_INSPECT_STR(user_data)
+                                << BATT_INSPECT(slots_found);
+
+                if (last_slot == "a") {
+                  ++run_length;
+
+                } else {
+                  BATT_CHECK_EQ(last_slot, std::string{"b"});
+
+                  EXPECT_EQ(run_length, last_run + 1);
+
+                  last_run = run_length;
+                  run_length = 0;
+                }
+                return batt::OkStatus();
+              });
+
+          ASSERT_TRUE(recovered_volume.ok()) << recovered_volume.status();
+
+          if (slots_found != 0) {
+            EXPECT_THAT(last_slot, ::testing::StrEq("b"));
+          }
+        }
+      });
+    }
+  }
+}
+
+}  // namespace

--- a/src/llfs/volume_multi_append.test.cpp
+++ b/src/llfs/volume_multi_append.test.cpp
@@ -13,6 +13,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <llfs/testing/test_config.hpp>
+
 #include <llfs/storage_simulation.hpp>
 
 #include <random>
@@ -24,11 +26,18 @@ using namespace llfs::constants;
 
 using llfs::StatusOr;
 
-TEST(VolumeMultiAppendTest, DISABLED_SimTest)
+TEST(VolumeMultiAppendTest, SimTest)
 {
-  for (u32 seed = 0; seed < 100; ++seed) {
-    for (usize n_before_crash = 1; n_before_crash < 20; ++n_before_crash) {
-      LLFS_LOG_INFO() << BATT_INSPECT(seed);
+  const std::string nonterminal(197, 'a');
+  const std::string terminal(193, 'b');
+
+  llfs::testing::TestConfig test_config;
+
+  const u32 kNumSeeds = test_config.extra_testing() ? 100 * 1000 : 400;
+
+  for (u32 seed = 0; seed < kNumSeeds; ++seed) {
+    for (usize n_before_crash : {1, 2, 3, 5, 10, 100, 500, 1000, 2000}) {
+      LLFS_VLOG(1) << BATT_INSPECT(seed) << BATT_INSPECT(n_before_crash);
       std::mt19937 rng{seed};
 
       llfs::StorageSimulation sim{batt::StateMachineEntropySource{
@@ -40,6 +49,11 @@ TEST(VolumeMultiAppendTest, DISABLED_SimTest)
       sim.run_main_task([&] {
         //+++++++++++-+-+--+----- --- -- -  -  -   -
         {
+          //----- --- -- -  -  -   -
+          // Recover the simulated Volume.
+          //
+          LLFS_VLOG(1) << "sim.get_volume()";
+
           StatusOr<std::unique_ptr<llfs::Volume>> recovered_volume = sim.get_volume(
               "TestVolume", /*slot_visitor_fn=*/
               [](auto&&...) {
@@ -51,54 +65,90 @@ TEST(VolumeMultiAppendTest, DISABLED_SimTest)
 
           llfs::Volume& volume = **recovered_volume;
 
+          //----- --- -- -  -  -   -
+          // Obtain a grant to append the entire contents of the root log.
+          //
           batt::Grant grant = BATT_OK_RESULT_OR_PANIC(
               volume.reserve(volume.available_to_reserve(), batt::WaitForResource::kFalse));
 
-          sim.set_inject_failures_mode(true);
+          // We will commit half the slots without failure injection, then turn on failure
+          // injection and allow errors to be handled.
+          //
+          sim.set_inject_failures_mode(false);
 
           batt::Optional<llfs::VolumeMultiAppend> op;
           usize pos_in_batch = 0;
           usize batch_size = 1;
+          bool first_half = true;
 
           for (usize i = 0; i < n_before_crash; ++i) {
+            // Check to see if it is time to turn on failure injection yet.
+            //
+            if (first_half && i >= n_before_crash / 2) {
+              first_half = false;
+              sim.set_inject_failures_mode(true);
+            }
+
+            // Open a multi-append if there isn't an active one.
+            //
             if (!op) {
               op.emplace(volume);
             }
 
+            // Allow the simulator to run some background tasks randomly.
+            //
             batt::Task::yield();
 
-            std::string_view s = (pos_in_batch + 1 < batch_size) ? "a" : "b";
+            // We write multi-appends in batches of increasing size: 1, 2, 3, 4...
+            // All multi-appends contain `nonterminal` slots followed by a single `terminal`
+            // slot.
+            //
+            std::string_view s = (pos_in_batch + 1 < batch_size) ? nonterminal : terminal;
 
             if (!op->append(s, grant).ok()) {
-              LLFS_LOG_INFO() << "Append error";
-              op->cancel();
+              // This is a valid path, as we aren't checking the grant to see if we have enough
+              // space in the log to add `s`.
+              //
+              LLFS_VLOG(1) << "Append error" << BATT_INSPECT(grant.size())
+                           << BATT_INSPECT(op->is_closed());
               break;
             }
 
+            // Increment our position in the current batch and see if the current batch is
+            // completed, in which case we commit the multi-append, reset state, and increment the
+            // batch_size.
+            //
             ++pos_in_batch;
             if (pos_in_batch == batch_size) {
               ++batch_size;
               pos_in_batch = 0;
               if (!op->commit(grant).ok()) {
-                LLFS_LOG_INFO() << "Commit error";
+                LLFS_VLOG(1) << "Commit error";
                 break;
               }
               op = batt::None;
             }
           }
 
-          if (op) {
+          // It's possible that we exited the loop while in the middle of an open multi-append; if
+          // so, cancel it now.
+          //
+          if (op && op->is_open()) {
             op->cancel();
             op = batt::None;
           }
         }
 
+        LLFS_VLOG(1) << "sim.inject_failures = false; crash_and_recover";
+
+        // Simulate a crash and recover.
+        //
         sim.set_inject_failures_mode(false);
         sim.crash_and_recover();
 
         //+++++++++++-+-+--+----- --- -- -  -  -   -
         {
-          std::string last_slot;
+          std::string_view last_slot;
           usize slots_found = 0;
           i32 last_run = -1;
           i32 run_length = 0;
@@ -109,14 +159,17 @@ TEST(VolumeMultiAppendTest, DISABLED_SimTest)
                 ++slots_found;
                 last_slot = user_data;
 
-                LLFS_LOG_INFO() << BATT_INSPECT(slot.offset) << BATT_INSPECT_STR(user_data)
-                                << BATT_INSPECT(slots_found);
+                LLFS_VLOG(1) << BATT_INSPECT(slot.offset) << BATT_INSPECT_STR(user_data)
+                             << BATT_INSPECT(slots_found);
 
-                if (last_slot == "a") {
+                if (last_slot == nonterminal) {
                   ++run_length;
 
                 } else {
-                  BATT_CHECK_EQ(last_slot, std::string{"b"});
+                  // If the slot data isn't `nonterminal`, and it isn't `terminal`, um... what is
+                  // it, and how did it get here??
+                  //
+                  BATT_CHECK_EQ(last_slot, terminal);
 
                   EXPECT_EQ(run_length, last_run + 1);
 
@@ -128,8 +181,12 @@ TEST(VolumeMultiAppendTest, DISABLED_SimTest)
 
           ASSERT_TRUE(recovered_volume.ok()) << recovered_volume.status();
 
+          // This is the crucial test -- the last slot observed should always be on a multi-append
+          // boundary.
+          //
           if (slots_found != 0) {
-            EXPECT_THAT(last_slot, ::testing::StrEq("b"));
+            EXPECT_THAT(last_slot, ::testing::StrEq(terminal))
+                << BATT_INSPECT(seed) << BATT_INSPECT(n_before_crash);
           }
         }
       });

--- a/src/llfs/volume_multi_append.test.cpp
+++ b/src/llfs/volume_multi_append.test.cpp
@@ -24,7 +24,7 @@ using namespace llfs::constants;
 
 using llfs::StatusOr;
 
-TEST(VolumeMultiAppendTest_DISABLED, SimTest)
+TEST(VolumeMultiAppendTest, DISABLED_SimTest)
 {
   for (u32 seed = 0; seed < 100; ++seed) {
     for (usize n_before_crash = 1; n_before_crash < 20; ++n_before_crash) {

--- a/src/llfs/volume_trimmer.test.cpp
+++ b/src/llfs/volume_trimmer.test.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <llfs/testing/fake_log_device.hpp>
+#include <llfs/testing/test_config.hpp>
 
 #include <llfs/log_device_snapshot.hpp>
 #include <llfs/pack_as_raw.hpp>
@@ -1031,9 +1032,9 @@ void VolumeTrimmerTest::TrimmerSession::terminate()
 //
 TEST_F(VolumeTrimmerTest, RandomizedTest)
 {
-  static const bool kExtraTesting =               //
-      batt::getenv_as<int>("LLFS_EXTRA_TESTING")  //
-          .value_or(0);
+  static llfs::testing::TestConfig test_config;
+
+  static const bool kExtraTesting = test_config.extra_testing();
 
   static const usize kNumSeeds =                   //
       batt::getenv_as<int>("LLFS_TEST_NUM_SEEDS")  //


### PR DESCRIPTION
- Adds `llfs::Volume::MultiAppend`, for atomic appending of multiple slots
- Fixes a bug in Volume's append job, where an error status returned from preparing the job could (incorrectly) fail a check (generating a panic)
- Adds support for block-device level simulation of LogDevice in StorageSimulation, based on IoRingLogDevice
- Fixes bug where moving an `IoRing` object after using it to construct an `IoRing::File` would result in a dangling pointer
- Minor enhancements to various APIs:
    - variable-length integer pack/unpack now accept `ConstBuffer`/`MutableBuffer`
    - `DataReader::read_token` added
    - separate `halt()` and `join()` member functions for `LogDevice`, instead of the combined `close()` function (now deprecated)
    - relax the restriction that `LogDevice::prepare` may only be called once per `commit` (now you can call it multiple times to progressively increase the size of the prepared buffer, provided there is space in the log)
- Consolidated various unit test configuration parameters in `llfs::testing::TestConfig` (`llfs/testing/test_config.hpp`)
- Renamed `llfs::PageArena::close` to `halt` to be more consistent with other parts of the code
- Added new diagnostics to `StorageSimulation` when a possible deadlock is detected (main test function has exited and there is no runnable work, but the work count on the simulation execution context is non-zero)
- Fixed a bug in static/runtime configuration of (ioring) log devices where it was possible to create more flush ops than the number of blocks in total, resulting in race conditions where multiple flush ops would write data to the same location(s)