### PR TITLE
Fix fd leak in RingBuffer; add fd tracking to find leaks (default off; opt-in).

### DIFF
--- a/src/llfs/filesystem.hpp
+++ b/src/llfs/filesystem.hpp
@@ -28,6 +28,16 @@ BATT_STRONG_TYPEDEF(bool, OpenForWrite);
 BATT_STRONG_TYPEDEF(bool, OpenForAppend);
 BATT_STRONG_TYPEDEF(bool, OpenRawIO);
 
+/** \brief Wrapper for all calls to system open; this allows us to track open file descriptors and
+ * where they were opened, to detect leaks.
+ */
+int system_open2(const char* path, int flags);
+
+/** \brief Wrapper for all calls to system open; this allows us to track open file descriptors and
+ * where they were opened, to detect leaks.
+ */
+int system_open3(const char* path, int flags, int mode);
+
 StatusOr<int> open_file_read_only(std::string_view file_name,
                                   OpenRawIO open_raw_io = OpenRawIO{false});
 

--- a/src/llfs/ioring.test.cpp
+++ b/src/llfs/ioring.test.cpp
@@ -69,7 +69,8 @@ TEST(IoRingTest, Test)
   StatusOr<IoRing> io = IoRing::make_new(llfs::MaxQueueDepth{64});
   ASSERT_TRUE(io.ok()) << io.status();
 
-  int fd = open("/tmp/llfs_ioring_test_file", O_CREAT | O_RDWR | O_DIRECT | O_SYNC, /*mode=*/0644);
+  int fd = llfs::system_open3("/tmp/llfs_ioring_test_file", O_CREAT | O_RDWR | O_DIRECT | O_SYNC,
+                              /*mode=*/0644);
   ASSERT_GE(fd, 0) << std::strerror(errno);
 
   std::array<char, 1023> buf;
@@ -125,8 +126,8 @@ TEST(IoRingTest, DISABLED_BlockDev)
   StatusOr<IoRing> io = IoRing::make_new(llfs::MaxQueueDepth{64});
   ASSERT_TRUE(io.ok()) << io.status();
 
-  int fd = open("/dev/nvme3n1", O_RDWR | O_DIRECT | O_SYNC);
-  int fd2 = open("/dev/nvme3n1", O_RDWR | O_DIRECT | O_SYNC);
+  int fd = llfs::system_open2("/dev/nvme3n1", O_RDWR | O_DIRECT | O_SYNC);
+  int fd2 = llfs::system_open2("/dev/nvme3n1", O_RDWR | O_DIRECT | O_SYNC);
 
   ASSERT_GE(fd, 0) << std::strerror(errno);
 
@@ -179,7 +180,7 @@ TEST(IoRingTest, MultipleThreads)
 
   const auto file_path = "/tmp/llfs_ioring_test_file";
 
-  int fd = open(file_path, O_CREAT | O_RDWR, /*mode=*/0644);
+  int fd = llfs::system_open3(file_path, O_CREAT | O_RDWR, /*mode=*/0644);
   ASSERT_GE(fd, 0) << std::strerror(errno);
 
   IoRing::File f{scoped_io_ring->get_io_ring(), fd};

--- a/src/llfs/ioring_file.cpp
+++ b/src/llfs/ioring_file.cpp
@@ -50,15 +50,7 @@ auto IoRing::File::operator=(File&& that) noexcept -> File&
 //
 IoRing::File::~File() noexcept
 {
-  if (this->fd_ != -1) {
-    if (this->registered_fd_ != -1) {
-      this->unregister_fd().IgnoreError();
-    }
-
-    batt::syscall_retry([&] {
-      return ::close(this->fd_);
-    });
-  }
+  this->close().IgnoreError();
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -139,10 +131,7 @@ Status IoRing::File::read_all_fixed(i64 offset, MutableBuffer buffer, int buf_in
 //
 int IoRing::File::release()
 {
-  if (this->registered_fd_ != -1) {
-    this->unregister_fd().IgnoreError();
-    this->registered_fd_ = -1;
-  }
+  this->unregister_fd().IgnoreError();
 
   int released = -1;
   std::swap(released, this->fd_);
@@ -176,10 +165,11 @@ Status IoRing::File::unregister_fd()
     return OkStatus();
   }
 
-  Status status = this->io_ring_impl_->unregister_fd(this->registered_fd_);
-  BATT_REQUIRE_OK(status);
-
+  const int local_registered_fd = this->registered_fd_;
   this->registered_fd_ = -1;
+
+  Status status = this->io_ring_impl_->unregister_fd(local_registered_fd);
+  BATT_REQUIRE_OK(status) << batt::LogLevel::kError;
 
   return OkStatus();
 }

--- a/src/llfs/ioring_file.test.cpp
+++ b/src/llfs/ioring_file.test.cpp
@@ -1,0 +1,61 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/ioring_file.hpp>
+//
+#include <llfs/ioring_file.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <llfs/filesystem.hpp>
+#include <llfs/track_fds.hpp>
+
+namespace {
+
+using namespace llfs::int_types;
+
+using llfs::Status;
+using llfs::StatusOr;
+
+TEST(IoringFileTest, FdLeakTest)
+{
+  bool saved = llfs::set_fd_tracking_enabled(true);
+  auto on_scope_exit = batt::finally([&] {
+    llfs::set_fd_tracking_enabled(saved);
+  });
+
+  StatusOr<llfs::ScopedIoRing> scoped_io_ring =
+      llfs::ScopedIoRing::make_new(llfs::MaxQueueDepth{32}, llfs::ThreadPoolSize{1});
+
+  ASSERT_TRUE(scoped_io_ring.ok()) << BATT_INSPECT(scoped_io_ring.status());
+
+  for (usize i = 0; i < 1000; ++i) {
+    std::set<int> before_fds = llfs::get_open_fds();
+    {
+      StatusOr<int> fd = llfs::open_file_read_only(__FILE__);
+      ASSERT_TRUE(fd.ok()) << BATT_INSPECT(fd.status());
+      {
+        llfs::IoRing::File file{scoped_io_ring->get_io_ring(), *fd};
+
+        Status register_status = file.register_fd();
+
+        EXPECT_TRUE(register_status.ok()) << BATT_INSPECT(register_status);
+
+        std::set<int> after_fds = llfs::get_open_fds();
+        EXPECT_NE(before_fds, after_fds)
+            << BATT_INSPECT_RANGE(before_fds) << BATT_INSPECT_RANGE(after_fds);
+      }
+    }
+    std::set<int> after_fds = llfs::get_open_fds();
+    EXPECT_EQ(before_fds, after_fds)
+        << BATT_INSPECT_RANGE(before_fds) << BATT_INSPECT_RANGE(after_fds) << BATT_INSPECT(i);
+  }
+}
+
+}  // namespace

--- a/src/llfs/ioring_file.test.cpp
+++ b/src/llfs/ioring_file.test.cpp
@@ -36,7 +36,8 @@ TEST(IoringFileTest, FdLeakTest)
   ASSERT_TRUE(scoped_io_ring.ok()) << BATT_INSPECT(scoped_io_ring.status());
 
   for (usize i = 0; i < 1000; ++i) {
-    std::set<int> before_fds = llfs::get_open_fds();
+    StatusOr<std::set<int>> before_fds = llfs::get_open_fds();
+    ASSERT_TRUE(before_fds.ok()) << BATT_INSPECT(before_fds.status());
     {
       StatusOr<int> fd = llfs::open_file_read_only(__FILE__);
       ASSERT_TRUE(fd.ok()) << BATT_INSPECT(fd.status());
@@ -47,14 +48,18 @@ TEST(IoringFileTest, FdLeakTest)
 
         EXPECT_TRUE(register_status.ok()) << BATT_INSPECT(register_status);
 
-        std::set<int> after_fds = llfs::get_open_fds();
+        StatusOr<std::set<int>> after_fds = llfs::get_open_fds();
+
+        ASSERT_TRUE(after_fds.ok()) << BATT_INSPECT(after_fds.status());
         EXPECT_NE(before_fds, after_fds)
-            << BATT_INSPECT_RANGE(before_fds) << BATT_INSPECT_RANGE(after_fds);
+            << BATT_INSPECT_RANGE(*before_fds) << BATT_INSPECT_RANGE(*after_fds);
       }
     }
-    std::set<int> after_fds = llfs::get_open_fds();
+    StatusOr<std::set<int>> after_fds = llfs::get_open_fds();
+
+    ASSERT_TRUE(after_fds.ok()) << BATT_INSPECT(after_fds.status());
     EXPECT_EQ(before_fds, after_fds)
-        << BATT_INSPECT_RANGE(before_fds) << BATT_INSPECT_RANGE(after_fds) << BATT_INSPECT(i);
+        << BATT_INSPECT_RANGE(*before_fds) << BATT_INSPECT_RANGE(*after_fds) << BATT_INSPECT(i);
   }
 }
 

--- a/src/llfs/ioring_file_runtime_options.cpp
+++ b/src/llfs/ioring_file_runtime_options.cpp
@@ -13,6 +13,8 @@
 #include <llfs/ioring_file_runtime_options.hpp>
 //
 
+#include <llfs/filesystem.hpp>
+
 namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -54,7 +56,7 @@ StatusOr<IoRing::File> open_ioring_file(const std::string& file_name,
   }
 
   int fd = batt::syscall_retry([&] {
-    return ::open(file_name.c_str(), flags);
+    return system_open2(file_name.c_str(), flags);
   });
   BATT_REQUIRE_OK(batt::status_from_retval(fd));
 

--- a/src/llfs/ioring_impl.cpp
+++ b/src/llfs/ioring_impl.cpp
@@ -12,6 +12,7 @@
 #ifndef LLFS_DISABLE_IO_URING
 
 #include <llfs/logging.hpp>
+#include <llfs/track_fds.hpp>
 
 #include <batteries/finally.hpp>
 
@@ -57,7 +58,7 @@ StatusOr<i32> status_or_i32_from_uring_retval(int retval)
     BATT_CHECK_EQ(impl->event_fd_, -1);
 
     LLFS_VLOG(1) << "Creating eventfd";
-    impl->event_fd_.store(eventfd(0, /*flags=*/EFD_SEMAPHORE));
+    impl->event_fd_.store(maybe_track_fd(eventfd(0, /*flags=*/EFD_SEMAPHORE)));
     if (impl->event_fd_ < 0) {
       LLFS_LOG_ERROR() << "failed to create eventfd: " << std::strerror(errno);
       return batt::status_from_retval(impl->event_fd_.load());

--- a/src/llfs/log_device_config.cpp
+++ b/src/llfs/log_device_config.cpp
@@ -86,7 +86,7 @@ StatusOr<std::unique_ptr<IoRingLogDeviceFactory>> recover_storage_object(
   const int flags = O_DIRECT | O_SYNC | O_RDWR;
 
   int fd = batt::syscall_retry([&] {
-    return ::open(file_name.c_str(), flags);
+    return system_open2(file_name.c_str(), flags);
   });
   BATT_REQUIRE_OK(batt::status_from_retval(fd));
 

--- a/src/llfs/raw_block_file_impl.cpp
+++ b/src/llfs/raw_block_file_impl.cpp
@@ -33,9 +33,9 @@ namespace llfs {
 {
   const int fd = batt::syscall_retry([&] {
     if (mode) {
-      return ::open(file_name, flags, *mode);
+      return system_open3(file_name, flags, *mode);
     } else {
-      return ::open(file_name, flags);
+      return system_open2(file_name, flags);
     }
   });
   BATT_REQUIRE_OK(batt::status_from_retval(fd));

--- a/src/llfs/ring_buffer.cpp
+++ b/src/llfs/ring_buffer.cpp
@@ -9,7 +9,9 @@
 #include <llfs/ring_buffer.hpp>
 //
 
+#include <llfs/filesystem.hpp>
 #include <llfs/status.hpp>
+#include <llfs/track_fds.hpp>
 
 #include <batteries/checked_cast.hpp>
 #include <batteries/env.hpp>
@@ -93,13 +95,12 @@ auto RingBuffer::ImplPool::allocate(const Params& params) noexcept -> Impl
 
         const i64 id = counter.fetch_add(1);
 
-        FILE* const fp = nullptr;
-
-        const int fd = memfd_create(Impl::memfd_name_from_id(id).c_str(), MFD_CLOEXEC);
+        const int fd =
+            maybe_track_fd(memfd_create(Impl::memfd_name_from_id(id).c_str(), MFD_CLOEXEC));
 
         return Impl{FileDescriptor{
                         .fd = fd,
-                        .fp = fp,
+                        .fp = nullptr,
                         .byte_size = p.byte_size,
                         .byte_offset = 0,
                         .truncate = true,
@@ -121,7 +122,7 @@ auto RingBuffer::ImplPool::allocate(const Params& params) noexcept -> Impl
           flags |= O_TRUNC;
         }
         return Impl{FileDescriptor{
-                        .fd = ::open(p.file_name.c_str(), flags, S_IRWXU),
+                        .fd = system_open3(p.file_name.c_str(), flags, S_IRWXU),
                         .fp = nullptr,
                         .byte_size = p.byte_size,
                         .byte_offset = p.byte_offset,
@@ -261,7 +262,11 @@ RingBuffer::Impl::~Impl() noexcept
       int local_fd = -1;
       std::swap(this->fd_, local_fd);
 
-      ::close(this->fd_);
+      Status close_status = close_fd(local_fd);
+      if (!close_status.ok()) {
+        LLFS_LOG_ERROR() << "Failed to close RingBuffer::Impl fd=" << local_fd
+                         << "; status=" << close_status;
+      }
     }
   }
 

--- a/src/llfs/track_fds.cpp
+++ b/src/llfs/track_fds.cpp
@@ -1,0 +1,188 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/track_fds.hpp>
+//
+
+#include <llfs/logging.hpp>
+
+#include <batteries/env.hpp>
+#include <batteries/suppress.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#ifdef __linux__
+//
+#include <dirent.h>
+#include <sys/types.h>
+//
+#endif
+
+namespace llfs {
+
+namespace {
+
+const char* kVarName = "LLFS_TRACK_FDS";
+
+struct TrackFdState {
+  std::atomic<bool> enabled{batt::getenv_as<int>(kVarName).value_or(0) != 0};
+  std::mutex mutex;
+  std::unordered_map<int, std::unique_ptr<boost::stacktrace::stacktrace>> traces;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  static TrackFdState& instance() noexcept
+  {
+    // Intentionally leaked.
+    //
+    static TrackFdState* const instance_ = new TrackFdState{};
+
+    return *instance_;
+  }
+};
+
+}  //namespace
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+std::set<int> get_open_fds()
+{
+  std::set<int> result;
+  const char* dirpath = "/proc/self/fd";
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+#ifdef __linux__
+  DIR* p_dir = opendir(dirpath);
+
+  if (!p_dir) {
+    LLFS_LOG_ERROR() << "Could not open " << dirpath;
+  } else {
+    auto on_scope_exit = batt::finally([&] {
+      closedir(p_dir);
+    });
+
+    const int p_dir_fd = dirfd(p_dir);
+
+    isize name_max = pathconf(dirpath, _PC_NAME_MAX);
+    if (name_max == -1) { /* Limit not defined, or error */
+      name_max = 255;     /* Take a guess */
+    }
+    const usize len = offsetof(struct dirent, d_name) + name_max + 1;
+    void* const entry_buffer = malloc(len);
+    auto on_scope_exit2 = batt::finally([&] {
+      free(entry_buffer);
+    });
+
+    for (;;) {
+      struct dirent* p_entry = nullptr;
+
+      BATT_SUPPRESS_IF_GCC("-Wdeprecated-declarations")
+      const int retval = readdir_r(p_dir, (struct dirent*)entry_buffer, &p_entry);
+      BATT_UNSUPPRESS_IF_GCC()
+
+      // Check for errors.
+      //
+      if (retval != 0) {
+        LLFS_LOG_ERROR() << "readdir_r returned: " << retval;
+        break;
+      }
+
+      // If p_entry is null, we are done!
+      //
+      if (!p_entry) {
+        break;
+      }
+
+      // If the entry name parses as an integer *and* it is not the open directory we are scanning,
+      // then add it to the result set.
+      //
+      std::optional<int> fd = batt::from_string<int>(p_entry->d_name);
+      if (fd && *fd != p_dir_fd) {
+        result.emplace(*fd);
+      }
+    }
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+#else
+  std::error_code ec;
+  std::filesystem::directory_iterator iter{dirpath, ec};
+  if (ec) {
+    LLFS_VLOG(1) << "failed to open '/proc/self/fd': " << ec.value() << ":" << ec.message();
+    return {};
+  }
+  LLFS_VLOG(1) << "open succeeded; gathering fds";
+
+  for (const std::filesystem::directory_entry& entry : iter) {
+    LLFS_VLOG(1) << BATT_INSPECT(entry.path().stem());
+    std::optional<int> fd = batt::from_string<int>(entry.path().stem().string());
+    if (!fd) {
+      continue;
+    }
+    result.emplace(*fd);
+  }
+#endif
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  return result;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+int maybe_track_fd(int fd)
+{
+  if (fd >= 0 && is_fd_tracking_enabled()) {
+    set_trace_for_fd(fd, boost::stacktrace::stacktrace{});
+  }
+  return fd;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+bool is_fd_tracking_enabled()
+{
+  return TrackFdState::instance().enabled.load();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+bool set_fd_tracking_enabled(bool on)
+{
+  return TrackFdState::instance().enabled.exchange(on);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Optional<boost::stacktrace::stacktrace> get_trace_for_fd(int fd)
+{
+  TrackFdState& state = TrackFdState::instance();
+  std::unique_lock<std::mutex> lock{state.mutex};
+  auto iter = state.traces.find(fd);
+  if (iter == state.traces.end() || iter->second == nullptr) {
+    return None;
+  }
+  return *iter->second;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void set_trace_for_fd(int fd, Optional<boost::stacktrace::stacktrace> trace)
+{
+  TrackFdState& state = TrackFdState::instance();
+  std::unique_lock<std::mutex> lock{state.mutex};
+  if (!trace) {
+    state.traces.erase(fd);
+  } else {
+    state.traces[fd] = std::make_unique<boost::stacktrace::stacktrace>(*trace);
+  }
+}
+
+}  //namespace llfs

--- a/src/llfs/track_fds.hpp
+++ b/src/llfs/track_fds.hpp
@@ -13,6 +13,7 @@
 #include <llfs/config.hpp>
 //
 #include <llfs/optional.hpp>
+#include <llfs/status.hpp>
 
 #include <boost/stacktrace/stacktrace.hpp>
 
@@ -22,7 +23,7 @@ namespace llfs {
 
 /** \brief Returns the set of currently open file descriptors for this process.
  */
-std::set<int> get_open_fds();
+StatusOr<std::set<int>> get_open_fds();
 
 /** \brief If tracking is enabled and fd is not invalid, adds it to the tracked set.
  * \return the passed fd

--- a/src/llfs/track_fds.hpp
+++ b/src/llfs/track_fds.hpp
@@ -1,0 +1,52 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_TRACK_FDS_HPP
+#define LLFS_TRACK_FDS_HPP
+
+#include <llfs/config.hpp>
+//
+#include <llfs/optional.hpp>
+
+#include <boost/stacktrace/stacktrace.hpp>
+
+#include <set>
+
+namespace llfs {
+
+/** \brief Returns the set of currently open file descriptors for this process.
+ */
+std::set<int> get_open_fds();
+
+/** \brief If tracking is enabled and fd is not invalid, adds it to the tracked set.
+ * \return the passed fd
+ */
+int maybe_track_fd(int fd);
+
+/** \brief Returns whether fd tracking is currently enabled for this process.
+ */
+bool is_fd_tracking_enabled();
+
+/** \brief Sets whether fd tracking is currently enabled for this process.
+ * \return the previous enabled status
+ */
+bool set_fd_tracking_enabled(bool on);
+
+/** \brief Returns the stack trace for the most recent open of the passed file descriptor, or None
+ * if no such trace exists.
+ */
+Optional<boost::stacktrace::stacktrace> get_trace_for_fd(int fd);
+
+/** \brief Sets the stack trace for the given file descriptor.
+ */
+void set_trace_for_fd(int fd, Optional<boost::stacktrace::stacktrace> trace);
+
+}  //namespace llfs
+
+#endif  // LLFS_TRACK_FDS_HPP

--- a/src/llfs/track_fds.test.cpp
+++ b/src/llfs/track_fds.test.cpp
@@ -21,7 +21,15 @@ namespace {
 
 TEST(TrackFdsTest, Test)
 {
-  LLFS_LOG_INFO() << batt::dump_range(llfs::get_open_fds());
+  llfs::StatusOr<std::set<int>> fds = llfs::get_open_fds();
+  ASSERT_TRUE(fds.ok()) << BATT_INSPECT(fds.status());
+
+  EXPECT_GE(fds->size(), 3u);
+  EXPECT_EQ(fds->count(0), 1u);
+  EXPECT_EQ(fds->count(1), 1u);
+  EXPECT_EQ(fds->count(2), 1u);
+
+  LLFS_LOG_INFO() << batt::dump_range(*fds);
 }
 
 }  // namespace

--- a/src/llfs/track_fds.test.cpp
+++ b/src/llfs/track_fds.test.cpp
@@ -1,0 +1,27 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/track_fds.hpp>
+//
+#include <llfs/track_fds.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <llfs/logging.hpp>
+
+#include <batteries/stream_util.hpp>
+
+namespace {
+
+TEST(TrackFdsTest, Test)
+{
+  LLFS_LOG_INFO() << batt::dump_range(llfs::get_open_fds());
+}
+
+}  // namespace


### PR DESCRIPTION
This PR fixes a file descriptor (fd) leak in `RingBuffer::Impl`.  It also adds some diagnostic tools to try to make it easier to find and diagnose future fd leaks.

- System `open` should only be called from `llfs::system_open3` and `llfs::system_open2`
- All other syscalls that allocate and return file descriptors (e.g. `eventfd` and `memfd`) should be wrapped in `llfs::maybe_track_fd`
- When fd tracking is enabled, any call to `maybe_track_fd` will add a stack trace associated with the passed fd to a global table
- The `llfs/track_fds.hpp` header provides the following API for debugging fd leaks:
    - `get_open_fds()` returns a set of the fds currently open by the calling process
    - `is_fd_tracking_enabled()` and `set_fd_tracking_enabled(bool)` allow querying and modifying the tracker status
    - `get_trace_for_fd(int fd)` will return the last stack trace associated with the passed fd, if there is one
    - `set_trace_for_fd(int fd, stacktrace)` allows a stack trace to be manually associated with a given fd

I also took the opportunity to clean up the code in `IoRing::File`, eliminating redundancy by calling existing functions.
