### PR TITLE
IoRingLogDevice2 trim bug and remove atomic slot range tokens.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -69,7 +69,7 @@ class LlfsConan(ConanFile):
 
 
     def requirements(self):
-        self.requires("batteries/0.53.0", **VISIBLE)
+        self.requires("batteries/0.55.1", **VISIBLE)
         self.requires("boost/1.83.0", **VISIBLE)
         self.requires("cli11/2.3.2", **VISIBLE)
         self.requires("glog/0.6.0", **VISIBLE)

--- a/src/llfs/basic_ring_buffer_log_device.hpp
+++ b/src/llfs/basic_ring_buffer_log_device.hpp
@@ -245,7 +245,11 @@ class BasicRingBufferLogDevice<Impl>::WriterImpl : public LogDevice::Writer
     const usize space_required = byte_count + head_room;
 
     if (this->space() < space_required) {
-      return ::llfs::make_status(StatusCode::kPrepareFailedTrimRequired);
+      BATT_REQUIRE_OK(::llfs::make_status(StatusCode::kPrepareFailedTrimRequired))
+          << BATT_INSPECT(space_required) << BATT_INSPECT(this->space())
+          << BATT_INSPECT(this->device_->driver_.get_trim_pos())
+          << BATT_INSPECT(this->device_->driver_.get_commit_pos())
+          << boost::stacktrace::stacktrace{};
     }
 
     const slot_offset_type commit_pos = this->device_->driver_.get_commit_pos();

--- a/src/llfs/ioring_log_device2.hpp
+++ b/src/llfs/ioring_log_device2.hpp
@@ -83,6 +83,7 @@ class IoRingLogDriver2
   Status set_trim_pos(slot_offset_type trim_pos)
   {
     this->observed_watch_[kTargetTrimPos].set_value(trim_pos);
+    BATT_REQUIRE_OK(this->await_trim_pos(trim_pos));
     return OkStatus();
   }
 

--- a/src/llfs/ioring_log_device2.test.cpp
+++ b/src/llfs/ioring_log_device2.test.cpp
@@ -36,7 +36,7 @@ using llfs::StatusOr;
 //     the confirmed trim and flush never go backwards, and that all confirmed flushed data can be
 //     read.
 //
-class IoringLogDevice2SimTest : public ::testing::Test
+class IoRingLogDevice2SimTest : public ::testing::Test
 {
  public:
   static constexpr usize kNumSeeds = 250 * 1000;
@@ -326,6 +326,8 @@ class IoringLogDevice2SimTest : public ::testing::Test
         if (!trim_status.ok()) {
           break;
         }
+        BATT_CHECK_EQ(this->log_device->slot_range(llfs::LogReadMode::kDurable).lower_bound,
+                      trimmed_slot.upper_bound);
 
         Status await_status = this->log_writer->await(llfs::BytesAvailable{
             .size = trimmed_slot.size() + observed_space,
@@ -503,11 +505,11 @@ class IoringLogDevice2SimTest : public ::testing::Test
 
   };  // struct Scenario
 
-};  // class IoringLogDevice2SimTest
+};  // class IoRingLogDevice2SimTest
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 
-TEST_F(IoringLogDevice2SimTest, Simulation)
+TEST_F(IoRingLogDevice2SimTest, Simulation)
 {
   const usize kNumThreads = std::thread::hardware_concurrency();
   const usize kUpdateInterval = kNumSeeds / 20;
@@ -558,7 +560,7 @@ TEST_F(IoringLogDevice2SimTest, Simulation)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-TEST(IoringLogDevice2Test, Benchmark)
+TEST(IoRingLogDevice2Test, Benchmark)
 {
   //+++++++++++-+-+--+----- --- -- -  -  -   -
   // Set configuration and options.

--- a/src/llfs/slot_writer.cpp
+++ b/src/llfs/slot_writer.cpp
@@ -59,67 +59,11 @@ void SlotWriter::halt()
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-/*static*/ Slice<const u8> SlotWriter::WriterLock::begin_atomic_range_token() noexcept
-{
-  const static std::array<u8, Self::kBeginAtomicRangeTokenSize> token_ = {0b10000000, 0b10000000,
-                                                                          0b00000000};
-  return as_const_slice(token_);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-/*static*/ Slice<const u8> SlotWriter::WriterLock::end_atomic_range_token() noexcept
-{
-  const static std::array<u8, Self::kEndAtomicRangeTokenSize> token_ = {0b10000000, 0b00000000};
-  return as_const_slice(token_);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
 /*explicit*/ SlotWriter::WriterLock::WriterLock(SlotWriter& slot_writer) noexcept
     : slot_writer_{slot_writer}
     , writer_lock_{this->slot_writer_.log_writer_}  // Lock the LogDevice::Writer mutex
 {
   BATT_CHECK_NOT_NULLPTR(*this->writer_lock_);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-Status SlotWriter::WriterLock::append_token_impl(const Slice<const u8>& token,
-                                                 const batt::Grant& caller_grant) noexcept
-{
-  BATT_CHECK_EQ(this->prepare_size_, 0u);
-
-  const usize prepare_size = this->deferred_commit_size_ + token.size();
-
-  if (caller_grant.size() < prepare_size) {
-    return ::llfs::make_status(StatusCode::kSlotGrantTooSmall);
-  }
-
-  BATT_ASSIGN_OK_RESULT(MutableBuffer buffer,
-                        (*this->writer_lock_)->prepare(prepare_size, /*head_room=*/0));
-
-  buffer += this->deferred_commit_size_;
-
-  std::memcpy(buffer.data(), token.begin(), token.size());
-
-  this->deferred_commit_size_ += token.size();
-
-  return batt::OkStatus();
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-Status SlotWriter::WriterLock::begin_atomic_range(const batt::Grant& caller_grant) noexcept
-{
-  return this->append_token_impl(Self::begin_atomic_range_token(), caller_grant);
-}
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-Status SlotWriter::WriterLock::end_atomic_range(const batt::Grant& caller_grant) noexcept
-{
-  return this->append_token_impl(Self::end_atomic_range_token(), caller_grant);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/slot_writer.test.cpp
+++ b/src/llfs/slot_writer.test.cpp
@@ -19,27 +19,4 @@ namespace {
 
 using namespace llfs::int_types;
 
-TEST(SlotWriterTest, BeginEndAtomicRangeTokens)
-{
-  llfs::Slice<const u8> begin_token = llfs::SlotWriter::WriterLock::begin_atomic_range_token();
-  llfs::Slice<const u8> end_token = llfs::SlotWriter::WriterLock::end_atomic_range_token();
-
-  EXPECT_EQ(begin_token.size(), llfs::SlotWriter::WriterLock::kBeginAtomicRangeTokenSize);
-  EXPECT_EQ(end_token.size(), llfs::SlotWriter::WriterLock::kEndAtomicRangeTokenSize);
-  EXPECT_NE(begin_token.size(), end_token.size());
-  EXPECT_GT(begin_token.size(), 1u);
-  EXPECT_GT(end_token.size(), 1u);
-
-  const auto verify_parses_as_zero = [](const llfs::Slice<const u8>& token) {
-    auto [parsed_n, end_of_parse] = llfs::unpack_varint_from(token.begin(), token.end());
-
-    ASSERT_TRUE(parsed_n);
-    EXPECT_EQ(*parsed_n, 0u);
-    EXPECT_EQ(end_of_parse, token.end());
-  };
-
-  verify_parses_as_zero(begin_token);
-  verify_parses_as_zero(end_token);
-}
-
 }  // namespace

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -41,6 +41,13 @@ const VolumeOptions& Volume::options() const
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
+const std::string& Volume::name() const noexcept
+{
+  return this->options().name;
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 const boost::uuids::uuid& Volume::get_volume_uuid() const
 {
   return this->volume_uuid_;
@@ -374,7 +381,7 @@ void Volume::start()
           Status result = this->trimmer_->run();
           LLFS_VLOG(1) << "Volume::trimmer_task_ exited with status=" << result;
         },
-        "Volume::trimmer_task_");
+        /*task_name=*/batt::to_string(this->name(), "_Volume.trimmer_task"));
   }
 }
 

--- a/src/llfs/volume.hpp
+++ b/src/llfs/volume.hpp
@@ -88,6 +88,10 @@ class Volume
   //
   const VolumeOptions& options() const;
 
+  /** \brief The name for this Volume, as specified by the VolumeOptions.
+   */
+  const std::string& name() const noexcept;
+
   // Returns the UUID for this volume.
   //
   const boost::uuids::uuid& get_volume_uuid() const;

--- a/src/llfs/volume_trimmer.cpp
+++ b/src/llfs/volume_trimmer.cpp
@@ -217,12 +217,12 @@ Status VolumeTrimmer::run()
     //+++++++++++-+-+--+----- --- -- -  -  -   -
     // Wait for the trim point to advance.
     //
-    BATT_DEBUG_INFO("waiting for trim target to advance; "
-                    << BATT_INSPECT(this->trim_control_.get_lower_bound())
-                    << BATT_INSPECT(least_upper_bound) << BATT_INSPECT(bytes_trimmed)
-                    << BATT_INSPECT(trim_lower_bound) << std::endl
-                    << BATT_INSPECT(this->trim_control_.debug_info()) << BATT_INSPECT(loop_counter)
-                    << BATT_INSPECT(this->trim_control_.is_closed()));
+    BATT_DEBUG_INFO(
+        "waiting for trim target to advance; "
+        << BATT_INSPECT(this->trim_control_.get_lower_bound()) << BATT_INSPECT(least_upper_bound)
+        << BATT_INSPECT(bytes_trimmed) << BATT_INSPECT(trim_lower_bound) << std::endl
+        << BATT_INSPECT(this->trim_control_.debug_info()) << BATT_INSPECT(loop_counter)
+        << BATT_INSPECT(this->trim_control_.is_closed()) << BATT_INSPECT(this->trim_delay_));
 
     StatusOr<slot_offset_type> trim_upper_bound = this->await_trim_target(least_upper_bound);
 


### PR DESCRIPTION
Fixes issue/159.

The fix is in `IoRingLogDriver2::set_trim_pos`:

```c++
BATT_REQUIRE_OK(this->await_trim_pos(trim_pos));
```