### PR TITLE
CachingPageTracer Optimization

### DIFF
--- a/src/llfs/api_types.hpp
+++ b/src/llfs/api_types.hpp
@@ -81,6 +81,8 @@ BATT_STRONG_TYPEDEF(usize, BufferCount);
  */
 BATT_STRONG_TYPEDEF(usize, BufferSize);
 
+BATT_STRONG_TYPEDEF(bool, HasNoOutgoingRefs);
+
 }  // namespace llfs
 
 #endif  // LLFS_API_TYPES_HPP

--- a/src/llfs/api_types.hpp
+++ b/src/llfs/api_types.hpp
@@ -81,7 +81,9 @@ BATT_STRONG_TYPEDEF(usize, BufferCount);
  */
 BATT_STRONG_TYPEDEF(usize, BufferSize);
 
-BATT_STRONG_TYPEDEF(bool, HasNoOutgoingRefs);
+/** \brief True if a page contains outgoing references to other pages.
+ */
+BATT_STRONG_TYPEDEF(bool, HasOutgoingRefs);
 
 }  // namespace llfs
 

--- a/src/llfs/committable_page_cache_job.cpp
+++ b/src/llfs/committable_page_cache_job.cpp
@@ -88,11 +88,8 @@ usize CommittablePageCacheJob::new_page_count() const noexcept
 //
 BoxedSeq<PageId> CommittablePageCacheJob::deleted_page_ids() const
 {
-  return as_seq(this->job_->get_deleted_pages().begin(), this->job_->get_deleted_pages().end())  //
-         | seq::map([](const auto& kv_pair) -> PageId {
-             return kv_pair.first;
-           })  //
-         | seq::boxed();
+  return BoxedSeq<PageId>{
+      as_seq(this->job_->get_deleted_pages().begin(), this->job_->get_deleted_pages().end())};
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -512,19 +509,23 @@ auto CommittablePageCacheJob::get_page_ref_count_updates(u64 /*callers*/) const
   // Trace deleted pages non-recursively, decrementing the ref counts of all pages they directly
   // reference.
   //
+  LoadingPageTracer loading_tracer{loader, true};
+  CachingPageTracer caching_tracer{this->job_->cache().devices_by_id(), loading_tracer};
   for (const auto& p : this->job_->get_deleted_pages()) {
-    // Sanity check; deleted pages should have a ref_count_delta of kRefCount_1_to_0.
-    //
-    const PageId deleted_page_id = p.first;
-    {
-      auto iter = ref_count_delta.find(deleted_page_id);
-      BATT_CHECK_NE(iter, ref_count_delta.end());
-      BATT_CHECK_EQ(iter->second, kRefCount_1_to_0);
-    }
+    const PageId deleted_page_id = p;
 
     // Decrement ref counts.
     //
-    p.second->trace_refs() | seq::for_each([&ref_count_delta, deleted_page_id](PageId id) {
+    batt::StatusOr<batt::BoxedSeq<PageId>> outgoing_refs =
+        caching_tracer.trace_page_refs(deleted_page_id);
+    if (outgoing_refs.status() == batt::StatusCode::kNotFound) {
+      continue;
+    }
+    BATT_REQUIRE_OK(outgoing_refs);
+
+    ref_count_delta[p] = kRefCount_1_to_0;
+
+    *outgoing_refs | seq::for_each([&ref_count_delta, deleted_page_id](PageId id) {
       if (id) {
         LLFS_VLOG(1) << " decrementing ref count for page " << id
                      << " (because it was referenced from deleted page " << deleted_page_id << ")";
@@ -596,14 +597,8 @@ Status CommittablePageCacheJob::drop_deleted_pages(u64 callers)
 {
   LLFS_VLOG(1) << "commit(PageCacheJob): dropping deleted pages";
 
-  const auto& deleted_pages = this->job_->get_deleted_pages();
-
-  return parallel_drop_pages(as_seq(deleted_pages.begin(), deleted_pages.end())  //
-                                 | seq::map([](const auto& kv_pair) -> PageId {
-                                     return kv_pair.first;
-                                   })  //
-                                 | seq::collect_vec(),
-                             this->job_->cache(), this->job_->job_id, callers);
+  return parallel_drop_pages(this->deleted_page_ids() | seq::collect_vec(), this->job_->cache(),
+                             this->job_->job_id, callers);
 }
 
 }  //namespace llfs

--- a/src/llfs/committable_page_cache_job.hpp
+++ b/src/llfs/committable_page_cache_job.hpp
@@ -193,7 +193,7 @@ class CommittablePageCacheJob
 
   Status write_new_pages();
 
-  StatusOr<PageRefCountUpdates> get_page_ref_count_updates(u64 callers) const;
+  StatusOr<PageRefCountUpdates> get_page_ref_count_updates(u64 callers);
 
   StatusOr<DeadPages> start_ref_count_updates(const JobCommitParams& params,
                                               PageRefCountUpdates& updates, u64 callers);
@@ -206,12 +206,15 @@ class CommittablePageCacheJob
 
   Status drop_deleted_pages(u64 callers);
 
+  BoxedSeq<PageId> finalized_deleted_page_ids() const;
+
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   std::shared_ptr<const PageCacheJob> job_;
   boost::intrusive_ptr<FinalizedJobTracker> tracker_;
   PageRefCountUpdates ref_count_updates_;
   std::unique_ptr<WriteNewPagesContext> write_new_pages_context_;
+  std::unordered_set<PageId, PageId::Hash> finalized_deleted_pages_;
 };
 
 /** \brief Write all changes in `job` to durable storage.  This is guaranteed to be atomic.

--- a/src/llfs/committable_page_cache_job.hpp
+++ b/src/llfs/committable_page_cache_job.hpp
@@ -206,15 +206,13 @@ class CommittablePageCacheJob
 
   Status drop_deleted_pages(u64 callers);
 
-  BoxedSeq<PageId> finalized_deleted_page_ids() const;
-
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   std::shared_ptr<const PageCacheJob> job_;
   boost::intrusive_ptr<FinalizedJobTracker> tracker_;
   PageRefCountUpdates ref_count_updates_;
   std::unique_ptr<WriteNewPagesContext> write_new_pages_context_;
-  std::unordered_set<PageId, PageId::Hash> finalized_deleted_pages_;
+  std::unordered_set<PageId, PageId::Hash> not_found_deleted_pages_;
 };
 
 /** \brief Write all changes in `job` to durable storage.  This is guaranteed to be atomic.

--- a/src/llfs/no_outgoing_refs_cache.cpp
+++ b/src/llfs/no_outgoing_refs_cache.cpp
@@ -1,0 +1,59 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+#include <llfs/no_outgoing_refs_cache.hpp>
+
+namespace llfs {
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+NoOutgoingRefsCache::NoOutgoingRefsCache(u64 physical_page_count) noexcept
+    : cache_(physical_page_count)
+{
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void NoOutgoingRefsCache::set_page_bits(i64 physical_page_id, page_generation_int generation,
+                                        HasNoOutgoingRefs has_no_out_going_refs)
+{
+  BATT_CHECK_LT((usize)physical_page_id, this->cache_.size());
+
+  u64 new_state = generation << this->generation_shift_;
+  // Set the "valid" bit to 1.
+  //
+  new_state |= (u64{1} << 1);
+  if (has_no_out_going_refs) {
+    // Set the "has no outgoing references" bit to 1.
+    //
+    new_state |= u64{1};
+  }
+
+  u64 old_state = this->cache_[physical_page_id].exchange(new_state, std::memory_order_acq_rel);
+  // Sanity check: we are not setting the bits for the same generation more than once.
+  //
+  page_generation_int old_generation = old_state >> this->generation_shift_;
+  BATT_CHECK_NE(generation, old_generation);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+u64 NoOutgoingRefsCache::get_page_bits(i64 physical_page_id, page_generation_int generation) const
+{
+  BATT_CHECK_LT((usize)physical_page_id, this->cache_.size());
+
+  u64 current_state = this->cache_[physical_page_id].load(std::memory_order_acquire);
+  page_generation_int stored_generation = current_state >> this->generation_shift_;
+  // If the generation that is currently stored in the cache is not the same as the generation we
+  // are querying for, this cache entry is invalid. Thus, we return a "not traced" status.
+  //
+  if (stored_generation != generation) {
+    return u64{0};
+  }
+  return current_state & this->bit_mask_;
+}
+}  // namespace llfs

--- a/src/llfs/no_outgoing_refs_cache.cpp
+++ b/src/llfs/no_outgoing_refs_cache.cpp
@@ -11,49 +11,65 @@ namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-NoOutgoingRefsCache::NoOutgoingRefsCache(u64 physical_page_count) noexcept
-    : cache_(physical_page_count)
+NoOutgoingRefsCache::NoOutgoingRefsCache(const PageIdFactory& page_ids) noexcept
+    : page_ids_{page_ids}
+    , cache_(this->page_ids_.get_physical_page_count().value())
 {
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-void NoOutgoingRefsCache::set_page_bits(i64 physical_page_id, page_generation_int generation,
-                                        HasNoOutgoingRefs has_no_out_going_refs)
+void NoOutgoingRefsCache::set_page_state(PageId page_id,
+                                         batt::BoolStatus new_has_outgoing_refs_state) noexcept
 {
-  BATT_CHECK_LT((usize)physical_page_id, this->cache_.size());
+  BATT_CHECK_EQ(PageIdFactory::get_device_id(page_id), this->page_ids_.get_device_id());
+  const u64 physical_page = this->page_ids_.get_physical_page(page_id);
+  const page_generation_int generation = this->page_ids_.get_generation(page_id);
+  BATT_CHECK_LT((usize)physical_page, this->cache_.size());
 
-  u64 new_state = generation << this->generation_shift_;
+  u64 new_cache_entry = generation << this->kGenerationShift;
+
   // Set the "valid" bit to 1.
   //
-  new_state |= (u64{1} << 1);
-  if (has_no_out_going_refs) {
+  new_cache_entry |= this->kValidBitMask;
+
+  // If new_has_outgoing_refs_state has value kFalse, page_id has no outgoing references.
+  //
+  if (new_has_outgoing_refs_state == batt::BoolStatus::kFalse) {
     // Set the "has no outgoing references" bit to 1.
     //
-    new_state |= u64{1};
+    new_cache_entry |= u64{1};
   }
 
-  u64 old_state = this->cache_[physical_page_id].exchange(new_state, std::memory_order_acq_rel);
+  u64 old_cache_entry =
+      this->cache_[physical_page].exchange(new_cache_entry, std::memory_order_acq_rel);
+
   // Sanity check: we are not setting the bits for the same generation more than once.
   //
-  page_generation_int old_generation = old_state >> this->generation_shift_;
+  page_generation_int old_generation = old_cache_entry >> this->kGenerationShift;
   BATT_CHECK_NE(generation, old_generation);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-u64 NoOutgoingRefsCache::get_page_bits(i64 physical_page_id, page_generation_int generation) const
+batt::BoolStatus NoOutgoingRefsCache::has_outgoing_refs(PageId page_id) const noexcept
 {
-  BATT_CHECK_LT((usize)physical_page_id, this->cache_.size());
+  BATT_CHECK_EQ(PageIdFactory::get_device_id(page_id), this->page_ids_.get_device_id());
+  const u64 physical_page = this->page_ids_.get_physical_page(page_id);
+  const page_generation_int generation = this->page_ids_.get_generation(page_id);
+  BATT_CHECK_LT((usize)physical_page, this->cache_.size());
 
-  u64 current_state = this->cache_[physical_page_id].load(std::memory_order_acquire);
-  page_generation_int stored_generation = current_state >> this->generation_shift_;
+  u64 current_cache_entry = this->cache_[physical_page].load(std::memory_order_acquire);
+  page_generation_int stored_generation = current_cache_entry >> this->kGenerationShift;
+  OutgoingRefsStatus outgoing_refs_status =
+      static_cast<OutgoingRefsStatus>(current_cache_entry & this->kOutgoingRefsBitMask);
+
   // If the generation that is currently stored in the cache is not the same as the generation we
-  // are querying for, this cache entry is invalid. Thus, we return a "not traced" status.
+  // are querying for, this cache entry is invalid. Thus, we return a "unknown" status.
   //
-  if (stored_generation != generation) {
-    return u64{0};
+  if (stored_generation != generation || outgoing_refs_status == OutgoingRefsStatus::kNotTraced) {
+    return batt::BoolStatus::kUnknown;
   }
-  return current_state & this->bit_mask_;
+  return batt::bool_status_from(outgoing_refs_status == OutgoingRefsStatus::kHasOutgoingRefs);
 }
 }  // namespace llfs

--- a/src/llfs/no_outgoing_refs_cache.hpp
+++ b/src/llfs/no_outgoing_refs_cache.hpp
@@ -1,0 +1,58 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_NO_OUTGOING_REFS_CACHE_HPP
+#define LLFS_NO_OUTGOING_REFS_CACHE_HPP
+
+#include <llfs/api_types.hpp>
+#include <llfs/page_id_factory.hpp>
+
+#include <atomic>
+#include <vector>
+
+namespace llfs {
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+/** \brief A cache to store outgoing refs information. Can be used by an implementer of PageTracer
+ * as a way to organize and look up this information on the PageDevice level. This cache is
+ * implemented as a vector of unsigned 64-bit integers, where every element of the vector
+ * represents the outgoing refs state of a physical page in a PageDevice. The lowest bit in an
+ * element represents if the page has no outgoing refs. The second lowest bit represents the
+ * validity of the page's state. the remaining upper 62 bits is used to store the generation of
+ * the physical page.
+ */
+class NoOutgoingRefsCache
+{
+ public:
+  explicit NoOutgoingRefsCache(u64 physical_page_count) noexcept;
+
+  NoOutgoingRefsCache(const NoOutgoingRefsCache&) = delete;
+  NoOutgoingRefsCache& operator=(const NoOutgoingRefsCache&) = delete;
+
+  //----- --- -- -  -  -   -
+  /** \brief Sets the two outgoing refs state bits for the given `physical_page_id` based on
+   * whether the page has outgoing refs or not, as indicated by `has_outgoing_refs`.
+   */
+  void set_page_bits(i64 physical_page_id, page_generation_int generation,
+                     HasNoOutgoingRefs has_no_outgoing_refs);
+
+  //----- --- -- -  -  -   -
+  /** \brief Retrieves the two outgoing refs state bits for the given `physical_page_id`.
+   *
+   * \return Can return a value of 0 (00), 2 (10), or 3 (11).
+   */
+  u64 get_page_bits(i64 physical_page_id, page_generation_int generation) const;
+
+ private:
+  std::vector<std::atomic<u64>> cache_;
+  static constexpr u64 bit_mask_ = 0b11;
+  static constexpr u8 generation_shift_ = 2;
+};
+}  // namespace llfs
+
+#endif // LLFS_NO_OUTGOING_REFS_CACHE_HPP

--- a/src/llfs/no_outgoing_refs_cache.hpp
+++ b/src/llfs/no_outgoing_refs_cache.hpp
@@ -13,10 +13,18 @@
 #include <llfs/api_types.hpp>
 #include <llfs/page_id_factory.hpp>
 
+#include <batteries/bool_status.hpp>
+
 #include <atomic>
 #include <vector>
 
 namespace llfs {
+enum struct OutgoingRefsStatus : u8 {
+  kNotTraced = 0,        // bit state 00, invalid
+  kHasOutgoingRefs = 2,  // bit state 10, valid with outgoing refs
+  kNoOutgoingRefs = 3,   // bit state 11, valid with no outgoing refs
+};
+
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 /** \brief A cache to store information about a page's outgoing references to other pages. Can be
  * used by an implementer of PageTracer as a way to organize and look up this information on the
@@ -29,29 +37,58 @@ namespace llfs {
 class NoOutgoingRefsCache
 {
  public:
-  explicit NoOutgoingRefsCache(u64 physical_page_count) noexcept;
+  explicit NoOutgoingRefsCache(const PageIdFactory& page_ids) noexcept;
 
   NoOutgoingRefsCache(const NoOutgoingRefsCache&) = delete;
   NoOutgoingRefsCache& operator=(const NoOutgoingRefsCache&) = delete;
 
   //----- --- -- -  -  -   -
-  /** \brief Sets the two outgoing refs state bits for the given `physical_page_id` based on
-   * whether the page has outgoing refs or not, as indicated by `has_outgoing_refs`.
+  /** \brief Sets the two outgoing refs state bits for the given `page_id` based on
+   * whether the page has outgoing refs or not, as indicated by `new_has_outgoing_refs_state`. This
+   * function also updates the generation stored in the cache for the physical page associated with
+   * `page_id`.
+   *
+   * @param page_id The id of the page whose outgoing refs information we are storing.
+   *
+   * @param new_has_outgoing_refs_state The status to store, indicating whether or not the page has
+   * outgoing refs. A value of `kFalse` indicates that the page does not have any outgoing refs, and
+   * a value of `kTrue` indicates that a page does have outgoing refs.
    */
-  void set_page_bits(i64 physical_page_id, page_generation_int generation,
-                     HasNoOutgoingRefs has_no_outgoing_refs);
+  void set_page_state(PageId page_id, batt::BoolStatus new_has_outgoing_refs_state) noexcept;
 
   //----- --- -- -  -  -   -
-  /** \brief Retrieves the two outgoing refs state bits for the given `physical_page_id`.
+  /** \brief Queries for whether or not the page with id `page_id` contains outgoing references to
+   * other pages.
    *
-   * \return Can return a value of 0 (00), 2 (10), or 3 (11).
+   * \return Returns a `batt::BoolStatus` type, where `kFalse` indicates that the page has no
+   * outgoing refs, `kTrue` indicates that the page does have outgoing refs, and `kUnknown`
+   * indicates that the cache entry for the given page does not have any valid information stored in
+   * it currently.
    */
-  u64 get_page_bits(i64 physical_page_id, page_generation_int generation) const;
+  batt::BoolStatus has_outgoing_refs(PageId page_id) const noexcept;
 
  private:
+  /** \brief A mask to retrieve the two outgoing refs state bits.
+   */
+  static constexpr u64 kOutgoingRefsBitMask = 0b11;
+
+  /** \brief A mask to access the "valid" bit of the two outgoing refs state bits.
+   */
+  static constexpr u64 kValidBitMask = 0b10;
+
+  /** \brief A constant representing the number of bits to shift a cache entry in order retrieve the
+   * generation stored.
+   */
+  static constexpr u8 kGenerationShift = 2;
+
+  /** \brief A PageIdFactory object to help resolve physical page and generation values from a
+   * PageId object.
+   */
+  const PageIdFactory page_ids_;
+
+  /** \brief The vector storing the cache entries, indexed by physical page id.
+   */
   std::vector<std::atomic<u64>> cache_;
-  static constexpr u64 bit_mask_ = 0b11;
-  static constexpr u8 generation_shift_ = 2;
 };
 }  // namespace llfs
 

--- a/src/llfs/no_outgoing_refs_cache.hpp
+++ b/src/llfs/no_outgoing_refs_cache.hpp
@@ -18,13 +18,13 @@
 
 namespace llfs {
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
-/** \brief A cache to store outgoing refs information. Can be used by an implementer of PageTracer
- * as a way to organize and look up this information on the PageDevice level. This cache is
- * implemented as a vector of unsigned 64-bit integers, where every element of the vector
- * represents the outgoing refs state of a physical page in a PageDevice. The lowest bit in an
- * element represents if the page has no outgoing refs. The second lowest bit represents the
- * validity of the page's state. the remaining upper 62 bits is used to store the generation of
- * the physical page.
+/** \brief A cache to store information about a page's outgoing references to other pages. Can be
+ * used by an implementer of PageTracer as a way to organize and look up this information on the
+ * PageDevice level. This cache is implemented as a vector of unsigned 64-bit integers, where every
+ * element of the vector represents the outgoing refs "state" of a physical page in a PageDevice.
+ * The lowest bit in an element represents if the page has no outgoing refs. The second lowest bit
+ * represents the validity of the page's state to help determine if a page's outgoing refs have ever
+ * been traced. The remaining upper 62 bits are used to store the generation of the physical page.
  */
 class NoOutgoingRefsCache
 {
@@ -55,4 +55,4 @@ class NoOutgoingRefsCache
 };
 }  // namespace llfs
 
-#endif // LLFS_NO_OUTGOING_REFS_CACHE_HPP
+#endif  // LLFS_NO_OUTGOING_REFS_CACHE_HPP

--- a/src/llfs/no_outgoing_refs_cache.hpp
+++ b/src/llfs/no_outgoing_refs_cache.hpp
@@ -19,11 +19,6 @@
 #include <vector>
 
 namespace llfs {
-enum struct OutgoingRefsStatus : u8 {
-  kNotTraced = 0,        // bit state 00, invalid
-  kHasOutgoingRefs = 2,  // bit state 10, valid with outgoing refs
-  kNoOutgoingRefs = 3,   // bit state 11, valid with no outgoing refs
-};
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 /** \brief A cache to store information about a page's outgoing references to other pages. Can be
@@ -33,6 +28,12 @@ enum struct OutgoingRefsStatus : u8 {
  * The lowest bit in an element represents if the page has no outgoing refs. The second lowest bit
  * represents the validity of the page's state to help determine if a page's outgoing refs have ever
  * been traced. The remaining upper 62 bits are used to store the generation of the physical page.
+ *
+ * Example cache entry: 0000000000000000000000000000000000000000000000000000000000000110
+ * The upper 62 bits represent generation, which in this case is 1. The second lowest bit is the
+ * validity bit, which is 1 here. This indicates that the page has been traced and therefore the
+ * cache entry contains valid information for the page of this generation. The lowest bit is 0,
+ * which indicates that the page has outgoing references to other pages.
  */
 class NoOutgoingRefsCache
 {
@@ -51,10 +52,10 @@ class NoOutgoingRefsCache
    * @param page_id The id of the page whose outgoing refs information we are storing.
    *
    * @param new_has_outgoing_refs_state The status to store, indicating whether or not the page has
-   * outgoing refs. A value of `kFalse` indicates that the page does not have any outgoing refs, and
-   * a value of `kTrue` indicates that a page does have outgoing refs.
+   * outgoing refs. A value of `false` indicates that the page does not have any outgoing refs, and
+   * a value of `true` indicates that a page does have outgoing refs.
    */
-  void set_page_state(PageId page_id, batt::BoolStatus new_has_outgoing_refs_state) noexcept;
+  void set_page_state(PageId page_id, HasOutgoingRefs new_has_outgoing_refs_state) noexcept;
 
   //----- --- -- -  -  -   -
   /** \brief Queries for whether or not the page with id `page_id` contains outgoing references to
@@ -68,13 +69,19 @@ class NoOutgoingRefsCache
   batt::BoolStatus has_outgoing_refs(PageId page_id) const noexcept;
 
  private:
-  /** \brief A mask to retrieve the two outgoing refs state bits.
+  /** \brief A mask to retrieve the lowest two outgoing refs state bits.
    */
-  static constexpr u64 kOutgoingRefsBitMask = 0b11;
+  static constexpr u64 kOutgoingRefsStatusBitsMask = 0b11;
 
-  /** \brief A mask to access the "valid" bit of the two outgoing refs state bits.
+  /** \brief A mask to access the "valid" bit of the two outgoing refs state bits. This is the
+   * higher of the two bits.
    */
   static constexpr u64 kValidBitMask = 0b10;
+
+  /** \brief A mask to access the "has no outgoing references" bit of the two outgoing refs state
+   * bits. This is the lower of the two bits.
+   */
+  static constexpr u64 kHasNoOutgoingRefsBitMask = 0b01;
 
   /** \brief A constant representing the number of bits to shift a cache entry in order retrieve the
    * generation stored.

--- a/src/llfs/page_cache.cpp
+++ b/src/llfs/page_cache.cpp
@@ -418,6 +418,8 @@ void PageCache::prefetch_hint(PageId page_id)
   (void)this->find_page_in_cache(page_id, /*require_tag=*/None, OkIfNotFound{false});
 }
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 const std::vector<std::unique_ptr<PageDeviceEntry>>& PageCache::devices_by_id() const
 {
   return this->page_devices_;
@@ -442,8 +444,7 @@ Slice<PageDeviceEntry* const> PageCache::devices_with_page_size(usize size) cons
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-Slice<PageDeviceEntry* const> PageCache::devices_with_page_size_log2(
-    usize size_log2) const
+Slice<PageDeviceEntry* const> PageCache::devices_with_page_size_log2(usize size_log2) const
 {
   BATT_CHECK_LT(size_log2, kMaxPageSizeLog2);
 

--- a/src/llfs/page_cache.cpp
+++ b/src/llfs/page_cache.cpp
@@ -22,7 +22,7 @@ namespace llfs {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-usize get_page_size(const PageCache::PageDeviceEntry* entry)
+usize get_page_size(const PageDeviceEntry* entry)
 {
   return entry ? get_page_size(entry->arena) : 0;
 }
@@ -418,16 +418,21 @@ void PageCache::prefetch_hint(PageId page_id)
   (void)this->find_page_in_cache(page_id, /*require_tag=*/None, OkIfNotFound{false});
 }
 
+const std::vector<std::unique_ptr<PageDeviceEntry>>& PageCache::devices_by_id() const
+{
+  return this->page_devices_;
+}
+
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-Slice<PageCache::PageDeviceEntry* const> PageCache::all_devices() const
+Slice<PageDeviceEntry* const> PageCache::all_devices() const
 {
   return as_slice(this->page_devices_by_page_size_);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-Slice<PageCache::PageDeviceEntry* const> PageCache::devices_with_page_size(usize size) const
+Slice<PageDeviceEntry* const> PageCache::devices_with_page_size(usize size) const
 {
   const usize size_log2 = batt::log2_ceil(size);
   BATT_CHECK_EQ(size, usize{1} << size_log2) << "page size must be a power of 2";
@@ -437,7 +442,7 @@ Slice<PageCache::PageDeviceEntry* const> PageCache::devices_with_page_size(usize
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-Slice<PageCache::PageDeviceEntry* const> PageCache::devices_with_page_size_log2(
+Slice<PageDeviceEntry* const> PageCache::devices_with_page_size_log2(
     usize size_log2) const
 {
   BATT_CHECK_LT(size_log2, kMaxPageSizeLog2);
@@ -533,7 +538,7 @@ void PageCache::purge(PageId page_id, u64 callers, u64 job_id)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-PageCache::PageDeviceEntry* PageCache::get_device_for_page(PageId page_id)
+PageDeviceEntry* PageCache::get_device_for_page(PageId page_id)
 {
   const page_device_id_int device_id = PageIdFactory::get_device_id(page_id);
   if (BATT_HINT_FALSE(device_id >= this->page_devices_.size())) {

--- a/src/llfs/page_cache.hpp
+++ b/src/llfs/page_cache.hpp
@@ -19,12 +19,11 @@
 #include <llfs/metrics.hpp>
 #include <llfs/optional.hpp>
 #include <llfs/page_allocator.hpp>
-#include <llfs/page_arena.hpp>
 #include <llfs/page_buffer.hpp>
 #include <llfs/page_cache_metrics.hpp>
 #include <llfs/page_cache_options.hpp>
 #include <llfs/page_device.hpp>
-#include <llfs/page_device_cache.hpp>
+#include <llfs/page_device_entry.hpp>
 #include <llfs/page_filter.hpp>
 #include <llfs/page_id_slot.hpp>
 #include <llfs/page_loader.hpp>
@@ -103,26 +102,6 @@ class PageCache : public PageLoader
     int line;
   };
 
-  /** \brief All the per-PageDevice state for a single device in the storage pool.
-   */
-  struct PageDeviceEntry {
-    explicit PageDeviceEntry(PageArena&& arena,
-                             boost::intrusive_ptr<PageCacheSlot::Pool>&& slot_pool) noexcept
-        : arena{std::move(arena)}
-        , cache{this->arena.device().page_ids(), std::move(slot_pool)}
-    {
-    }
-
-    /** \brief The PageDevice and PageAllocator.
-     */
-    PageArena arena;
-
-    /** \brief A per-device page cache; shares a PageCacheSlot::Pool with all other PageDeviceEntry
-     * objects that have the same page size.
-     */
-    PageDeviceCache cache;
-  };
-
   class PageDeleterImpl : public PageDeleter
   {
    public:
@@ -194,6 +173,8 @@ class PageCache : public PageLoader
   Slice<PageDeviceEntry* const> devices_with_page_size(usize size) const;
 
   Slice<PageDeviceEntry* const> all_devices() const;
+
+  const std::vector<std::unique_ptr<PageDeviceEntry>>& devices_by_id() const;
 
   const PageArena& arena_for_page_id(PageId id_val) const;
 

--- a/src/llfs/page_cache_job.cpp
+++ b/src/llfs/page_cache_job.cpp
@@ -356,17 +356,10 @@ Status PageCacheJob::delete_page(PageId page_id)
   if (!page_id) {
     return OkStatus();
   }
-  StatusOr<PinnedPage> page_view = this->get_page(page_id, OkIfNotFound{true});
-  if (page_view.ok()) {
-    this->pruned_ = false;
-    this->deleted_pages_.emplace(page_id, *page_view);
-    this->root_set_delta_[page_id] = kRefCount_1_to_0;
-    return OkStatus();
-  }
-  if (page_view.status() == batt::StatusCode::kNotFound) {
-    return OkStatus();
-  }
-  return page_view.status();
+
+  this->deleted_pages_.insert(page_id);
+  this->pruned_ = false;
+  return OkStatus();
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/llfs/page_cache_job.hpp
+++ b/src/llfs/page_cache_job.hpp
@@ -177,9 +177,7 @@ class PageCacheJob : public PageLoader
   Status recover_page(PageId page_id, const boost::uuids::uuid& caller_uuid,
                       slot_offset_type caller_slot);
 
-  // Mark the page as deleted in this job.  Will load the page as a side-effect, in order to access
-  // the set of pages referenced by the page contents.  Returns `true` if the page is being deleted;
-  // `false` if it doesn't exist (i.e., it was already deleted).
+  // Mark the page as deleted in this job.
   //
   Status delete_page(PageId page_id);
 

--- a/src/llfs/page_cache_job.hpp
+++ b/src/llfs/page_cache_job.hpp
@@ -258,8 +258,9 @@ class PageCacheJob : public PageLoader
   Status trace_new_roots(PageLoader& page_loader, PageIdFn&& page_id_fn) const
   {
     LoadingPageTracer loading_tracer{page_loader};
+    CachingPageTracer caching_tracer{this->cache().devices_by_id(), loading_tracer};
     return trace_refs_recursive(
-        loading_tracer,
+        caching_tracer,
 
         // Trace all new pages in the root set.
         //
@@ -303,7 +304,7 @@ class PageCacheJob : public PageLoader
     return this->new_pages_;
   }
 
-  const std::unordered_map<PageId, PinnedPage, PageId::Hash>& get_deleted_pages() const
+  const std::unordered_set<PageId, PageId::Hash>& get_deleted_pages() const
   {
     return this->deleted_pages_;
   }
@@ -327,7 +328,7 @@ class PageCacheJob : public PageLoader
   PageCache* const cache_;
   std::unordered_map<PageId, PinnedPage, PageId::Hash> pinned_;
   std::unordered_map<PageId, NewPage, PageId::Hash> new_pages_;
-  std::unordered_map<PageId, PinnedPage, PageId::Hash> deleted_pages_;
+  std::unordered_set<PageId, PageId::Hash> deleted_pages_;
   std::unordered_map<PageId, i32, PageId::Hash> root_set_delta_;
   std::unordered_map<PageId, std::function<auto()->std::shared_ptr<PageView>>, PageId::Hash>
       deferred_new_pages_;

--- a/src/llfs/page_device_entry.hpp
+++ b/src/llfs/page_device_entry.hpp
@@ -15,6 +15,7 @@
 #include <llfs/page_device_cache.hpp>
 
 namespace llfs {
+
 /** \brief All the per-PageDevice state for a single device in the storage pool.
  */
 struct PageDeviceEntry {
@@ -22,7 +23,7 @@ struct PageDeviceEntry {
                            boost::intrusive_ptr<PageCacheSlot::Pool>&& slot_pool) noexcept
       : arena{std::move(arena)}
       , cache{this->arena.device().page_ids(), std::move(slot_pool)}
-      , no_outgoing_refs_cache{this->arena.device().capacity().value()}
+      , no_outgoing_refs_cache{this->arena.device().page_ids()}
   {
   }
 

--- a/src/llfs/page_device_entry.hpp
+++ b/src/llfs/page_device_entry.hpp
@@ -1,0 +1,45 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_PAGE_DEVICE_ENTRY_HPP
+#define LLFS_PAGE_DEVICE_ENTRY_HPP
+
+#include <llfs/no_outgoing_refs_cache.hpp>
+#include <llfs/page_arena.hpp>
+#include <llfs/page_device_cache.hpp>
+
+namespace llfs {
+/** \brief All the per-PageDevice state for a single device in the storage pool.
+ */
+struct PageDeviceEntry {
+  explicit PageDeviceEntry(PageArena&& arena,
+                           boost::intrusive_ptr<PageCacheSlot::Pool>&& slot_pool) noexcept
+      : arena{std::move(arena)}
+      , cache{this->arena.device().page_ids(), std::move(slot_pool)}
+      , no_outgoing_refs_cache{this->arena.device().capacity().value()}
+  {
+  }
+
+  /** \brief The PageDevice and PageAllocator.
+   */
+  PageArena arena;
+
+  /** \brief A per-device page cache; shares a PageCacheSlot::Pool with all other PageDeviceEntry
+   * objects that have the same page size.
+   */
+  PageDeviceCache cache;
+
+  /** \brief A per-device tracker of the outgoing reference status of each physical page in the
+   * device.
+   */
+  NoOutgoingRefsCache no_outgoing_refs_cache;
+};
+}  // namespace llfs
+
+#endif // LLFS_PAGE_DEVICE_ENTRY_HPP

--- a/src/llfs/page_device_entry.hpp
+++ b/src/llfs/page_device_entry.hpp
@@ -42,4 +42,4 @@ struct PageDeviceEntry {
 };
 }  // namespace llfs
 
-#endif // LLFS_PAGE_DEVICE_ENTRY_HPP
+#endif  // LLFS_PAGE_DEVICE_ENTRY_HPP

--- a/src/llfs/page_tracer.cpp
+++ b/src/llfs/page_tracer.cpp
@@ -93,7 +93,7 @@ batt::StatusOr<batt::BoxedSeq<PageId>> CachingPageTracer::trace_page_refs(
       new_status_has_refs = true;
     }
     this->page_devices_[device_id]->no_outgoing_refs_cache.set_page_state(
-        from_page_id, batt::bool_status_from(HasOutgoingRefs{new_status_has_refs}));
+        from_page_id, HasOutgoingRefs{new_status_has_refs});
   }
 
   return outgoing_refs;

--- a/src/llfs/page_tracer.cpp
+++ b/src/llfs/page_tracer.cpp
@@ -10,9 +10,16 @@
 
 namespace llfs {
 
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// class LoadingPageTracer
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-LoadingPageTracer::LoadingPageTracer(PageLoader& page_loader) noexcept : page_loader_{page_loader}
+LoadingPageTracer::LoadingPageTracer(PageLoader& page_loader,
+                                     batt::Optional<bool> ok_if_not_found) noexcept
+    : page_loader_{page_loader}
+    , ok_if_not_found_{*ok_if_not_found}
 {
 }
 
@@ -28,13 +35,71 @@ batt::StatusOr<batt::BoxedSeq<PageId>> LoadingPageTracer::trace_page_refs(
     PageId from_page_id) noexcept
 {
   batt::StatusOr<PinnedPage> status_or_page =
-      this->page_loader_.get_page(from_page_id, OkIfNotFound{false});
+      this->page_loader_.get_page(from_page_id, OkIfNotFound{this->ok_if_not_found_});
   BATT_REQUIRE_OK(status_or_page);
 
   this->pinned_page_ = std::move(*status_or_page);
   BATT_CHECK_NOT_NULLPTR(this->pinned_page_);
 
   return this->pinned_page_->trace_refs();
+}
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+// class CachingPageTracer
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+CachingPageTracer::CachingPageTracer(
+    const std::vector<std::unique_ptr<PageDeviceEntry>>& page_devices,
+    PageTracer& loader_) noexcept
+    : page_devices_{page_devices}
+    , loader_{loader_}
+{
+}
+
+CachingPageTracer::~CachingPageTracer()
+{
+}
+
+batt::StatusOr<batt::BoxedSeq<PageId>> CachingPageTracer::trace_page_refs(
+    PageId from_page_id) noexcept
+{
+  const page_device_id_int device_id = PageIdFactory::get_device_id(from_page_id);
+  BATT_CHECK_LT(device_id, this->page_devices_.size());
+  const u64 physical_page =
+      this->page_devices_[device_id]->arena.device().page_ids().get_physical_page(from_page_id);
+  const page_generation_int generation =
+      this->page_devices_[device_id]->arena.device().page_ids().get_generation(from_page_id);
+
+  const OutgoingRefsStatus outgoing_refs_status = static_cast<OutgoingRefsStatus>(
+      this->page_devices_[device_id]->no_outgoing_refs_cache.get_page_bits(physical_page,
+                                                                           generation));
+
+  // If we already have information that this page has no outgoing refs, do not load the page and
+  // call trace refs; there's nothing we need to do.
+  //
+  if (outgoing_refs_status == OutgoingRefsStatus::kNoOutgoingRefs) {
+    return batt::seq::Empty<PageId>{} | batt::seq::boxed();
+  }
+
+  // If outgoing_refs_status has any other status, we must call trace_refs and set
+  // the outgoing refs information if it hasn't ever been traced before.
+  //
+  batt::StatusOr<batt::BoxedSeq<PageId>> outgoing_refs =
+      this->loader_.trace_page_refs(from_page_id);
+  BATT_REQUIRE_OK(outgoing_refs);
+
+  if (outgoing_refs_status == OutgoingRefsStatus::kNotTraced) {
+    bool new_status_no_refs = true;
+    if ((*outgoing_refs).peek()) {
+      new_status_no_refs = false;
+    }
+    this->page_devices_[device_id]->no_outgoing_refs_cache.set_page_bits(
+        physical_page, generation, HasNoOutgoingRefs{new_status_no_refs});
+  }
+
+  return outgoing_refs;
 }
 
 }  // namespace llfs

--- a/src/llfs/page_tracer.cpp
+++ b/src/llfs/page_tracer.cpp
@@ -51,17 +51,20 @@ batt::StatusOr<batt::BoxedSeq<PageId>> LoadingPageTracer::trace_page_refs(
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 CachingPageTracer::CachingPageTracer(
-    const std::vector<std::unique_ptr<PageDeviceEntry>>& page_devices,
-    PageTracer& loader_) noexcept
+    const std::vector<std::unique_ptr<PageDeviceEntry>>& page_devices, PageTracer& loader) noexcept
     : page_devices_{page_devices}
-    , loader_{loader_}
+    , loader_{loader}
 {
 }
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 CachingPageTracer::~CachingPageTracer()
 {
 }
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 batt::StatusOr<batt::BoxedSeq<PageId>> CachingPageTracer::trace_page_refs(
     PageId from_page_id) noexcept
 {

--- a/src/llfs/page_tracer.hpp
+++ b/src/llfs/page_tracer.hpp
@@ -51,10 +51,9 @@ class PageTracer
 class LoadingPageTracer : public PageTracer
 {
  public:
-  explicit LoadingPageTracer(PageLoader& page_loader,
-                             batt::Optional<bool> ok_if_not_found = false) noexcept;
+  explicit LoadingPageTracer(PageLoader& page_loader, bool ok_if_not_found = false) noexcept;
 
-  ~LoadingPageTracer();
+  ~LoadingPageTracer() noexcept;
 
   LoadingPageTracer(const LoadingPageTracer&) = delete;
   LoadingPageTracer& operator=(const LoadingPageTracer&) = delete;
@@ -79,12 +78,6 @@ class LoadingPageTracer : public PageTracer
   bool ok_if_not_found_;
 };
 
-enum struct OutgoingRefsStatus : u8 {
-  kNotTraced = 0,        // bit state 00, invalid
-  kHasOutgoingRefs = 2,  // bit state 10, valid with outgoing refs
-  kNoOutgoingRefs = 3,   // bit state 11, valid with no outgoing refs
-};
-
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 /** \brief A PageTracer with the ability to load a page and trace its outgoing references to other
  * pages, as well as look up cached information about a page's outgoing references to other pages.
@@ -101,7 +94,7 @@ class CachingPageTracer : public PageTracer
   CachingPageTracer(const CachingPageTracer&) = delete;
   CachingPageTracer operator=(const CachingPageTracer&) = delete;
 
-  ~CachingPageTracer();
+  ~CachingPageTracer() noexcept;
 
   /** \brief Traces the outgoing references of the page with page id `from_page_id`. First, this
    * function will attempt to see if there exists any cached information about the page's outgoing

--- a/src/llfs/page_tracer.test.cpp
+++ b/src/llfs/page_tracer.test.cpp
@@ -93,4 +93,238 @@ TEST(PageTracerMockTest, TraceRefsRecursiveTest)
   //
   EXPECT_EQ(expected_total_num_edges, calculated_num_edges);
 }
+
+class PageTracerTest : public ::testing::Test
+{
+ public:
+  using PageTracerTestEvent = llfs::PackedVariant<llfs::PackedPageId>;
+
+  void SetUp() override
+  {
+    this->reset_cache();
+    this->reset_logs();
+  }
+
+  void TearDown() override
+  {
+  }
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  void reset_cache()
+  {
+    llfs::StatusOr<batt::SharedPtr<llfs::PageCache>> page_cache_created =
+        llfs::make_memory_page_cache(batt::Runtime::instance().default_scheduler(),
+                                     /*arena_sizes=*/
+                                     {
+                                         {llfs::PageCount{16}, llfs::PageSize{256}},
+                                     },
+                                     this->max_refs_per_page);
+
+    ASSERT_TRUE(page_cache_created.ok());
+
+    this->page_cache = std::move(*page_cache_created);
+    batt::Status register_reader_status =
+        this->page_cache->register_page_reader(llfs::PageGraphNodeView::page_layout_id(), __FILE__,
+                                               __LINE__, llfs::PageGraphNodeView::page_reader());
+    ASSERT_TRUE(register_reader_status.ok());
+  }
+
+  void reset_logs()
+  {
+    this->root_log.emplace(2 * kMiB);
+
+    const auto recycler_options =
+        llfs::PageRecyclerOptions{}.set_max_refs_per_page(this->max_refs_per_page);
+
+    const u64 recycler_log_size = llfs::PageRecycler::calculate_log_size(recycler_options);
+
+    EXPECT_GE(::llfs::PageRecycler::calculate_max_buffered_page_count(recycler_options,
+                                                                      recycler_log_size),
+              llfs::PageRecycler::default_max_buffered_page_count(recycler_options));
+
+    this->recycler_log.emplace(recycler_log_size);
+  }
+
+  template <typename SlotVisitorFn>
+  std::unique_ptr<llfs::Volume> open_volume_or_die(llfs::LogDeviceFactory& root_log,
+                                                   llfs::LogDeviceFactory& recycler_log,
+                                                   SlotVisitorFn&& slot_visitor_fn)
+  {
+    llfs::StatusOr<std::unique_ptr<llfs::Volume>> test_volume_recovered = llfs::Volume::recover(
+        llfs::VolumeRecoverParams{
+            &batt::Runtime::instance().default_scheduler(),
+            llfs::VolumeOptions{
+                .name = "test_volume",
+                .uuid = llfs::None,
+                .max_refs_per_page = this->max_refs_per_page,
+                .trim_lock_update_interval = llfs::TrimLockUpdateInterval{0u},
+                .trim_delay_byte_count = this->trim_delay,
+            },
+            this->page_cache,
+            /*root_log=*/&root_log,
+            /*recycler_log=*/&recycler_log,
+            nullptr,
+        },  //
+        BATT_FORWARD(slot_visitor_fn));
+
+    BATT_CHECK(test_volume_recovered.ok()) << BATT_INSPECT(test_volume_recovered.status());
+
+    return std::move(*test_volume_recovered);
+  }
+
+  batt::StatusOr<llfs::PageId> build_page_with_refs_to(
+      const std::vector<llfs::PageId>& referenced_page_ids, llfs::PageSize page_size,
+      llfs::PageCacheJob& job)
+  {
+    batt::StatusOr<llfs::PageGraphNodeBuilder> page_builder =
+        llfs::PageGraphNodeBuilder::from_new_page(job.new_page(
+            page_size, batt::WaitForResource::kFalse, llfs::PageGraphNodeView::page_layout_id(),
+            /*callers=*/0, /*cancel_token=*/llfs::None));
+
+    BATT_REQUIRE_OK(page_builder);
+
+    for (llfs::PageId page_id : referenced_page_ids) {
+      page_builder->add_page(page_id);
+    }
+
+    batt::StatusOr<llfs::PinnedPage> pinned_page = std::move(*page_builder).build(job);
+    BATT_REQUIRE_OK(pinned_page);
+
+    return pinned_page->page_id();
+  }
+
+  batt::StatusOr<llfs::SlotRange> commit_job(llfs::Volume& test_volume,
+                                             std::unique_ptr<llfs::PageCacheJob> job,
+                                             llfs::PageId page_id)
+  {
+    auto event = llfs::pack_as_variant<PageTracerTestEvent>(llfs::PackedPageId::from(page_id));
+
+    llfs::StatusOr<llfs::AppendableJob> appendable_job =
+        llfs::make_appendable_job(std::move(job), llfs::PackableRef{event});
+
+    BATT_REQUIRE_OK(appendable_job);
+
+    const usize required_size = test_volume.calculate_grant_size(*appendable_job);
+
+    LLFS_VLOG(1) << BATT_INSPECT(required_size);
+
+    llfs::StatusOr<batt::Grant> grant =
+        test_volume.reserve(required_size, batt::WaitForResource::kFalse);
+
+    BATT_REQUIRE_OK(grant);
+
+    EXPECT_EQ(grant->size(), required_size);
+
+    return test_volume.append(std::move(*appendable_job), *grant);
+  }
+
+  const llfs::MaxRefsPerPage max_refs_per_page{8};
+
+  llfs::TrimDelayByteCount trim_delay{0};
+
+  batt::SharedPtr<llfs::PageCache> page_cache;
+
+  llfs::Optional<llfs::MemoryLogDevice> root_log;
+
+  llfs::Optional<llfs::MemoryLogDevice> recycler_log;
+};
+
+TEST_F(PageTracerTest, NoOutgoingRefsCacheDeath)
+{
+  const std::unique_ptr<llfs::PageDeviceEntry>& page_device1 = this->page_cache->devices_by_id()[0];
+
+  llfs::PageId page = page_device1->arena.device().page_ids().make_page_id(1, 1);
+
+  page_device1->no_outgoing_refs_cache.set_page_bits(1, 1, llfs::HasNoOutgoingRefs{true});
+  u64 page_bits = page_device1->no_outgoing_refs_cache.get_page_bits(1, 1);
+  EXPECT_EQ(page_bits, 3);
+
+  EXPECT_DEATH(
+      page_device1->no_outgoing_refs_cache.set_page_bits(1, 1, llfs::HasNoOutgoingRefs{true}),
+      "Assertion failed: generation != old_generation");
+
+  page = page_device1->arena.device().page_ids().make_page_id(2, 1);
+  page_device1->no_outgoing_refs_cache.set_page_bits(2, 1, llfs::HasNoOutgoingRefs{true});
+  page_device1->no_outgoing_refs_cache.set_page_bits(2, 2, llfs::HasNoOutgoingRefs{true});
+  page_bits = page_device1->no_outgoing_refs_cache.get_page_bits(2, 1);
+  EXPECT_EQ(page_bits, 0);
+}
+
+TEST_F(PageTracerTest, CachingPageTracerTest)
+{
+  std::unique_ptr<llfs::PageCacheJob> job = this->page_cache->new_job();
+
+  std::unordered_set<llfs::PageId, llfs::PageId::Hash> not_traced_set;
+  std::vector<llfs::PageId> leaves;
+  std::unordered_map<llfs::PageId, llfs::OutgoingRefsStatus, llfs::PageId::Hash>
+      expected_outgoing_refs_status;
+
+  for (usize i = 0; i < 8; ++i) {
+    batt::StatusOr<llfs::PageId> leaf =
+        this->build_page_with_refs_to({}, llfs::PageSize{256}, *job);
+    ASSERT_TRUE(leaf.ok()) << BATT_INSPECT(leaf.status());
+    not_traced_set.insert(*leaf);
+    leaves.emplace_back(*leaf);
+    expected_outgoing_refs_status[*leaf] = llfs::OutgoingRefsStatus::kNoOutgoingRefs;
+  }
+
+  u64 num_pages_with_outgoing_refs = 0;
+  for (usize i = 1; i < 8; ++i) {
+    std::mt19937 rng{i};
+    std::vector<llfs::PageId> outgoing_refs;
+    std::sample(leaves.begin(), leaves.end(), std::back_inserter(outgoing_refs), i, rng);
+    batt::StatusOr<llfs::PageId> root =
+        this->build_page_with_refs_to(outgoing_refs, llfs::PageSize{256}, *job);
+    job->new_root(*root);
+    expected_outgoing_refs_status[*root] = llfs::OutgoingRefsStatus::kHasOutgoingRefs;
+    ++num_pages_with_outgoing_refs;
+
+    for (usize j = 0; j < outgoing_refs.size(); ++j) {
+      not_traced_set.erase(outgoing_refs[j]);
+    }
+  }
+
+  batt::StatusOr<llfs::PageId> island =
+      this->build_page_with_refs_to({}, llfs::PageSize{256}, *job);
+  not_traced_set.insert(*island);
+  for (const llfs::PageId& id : not_traced_set) {
+    expected_outgoing_refs_status[id] = llfs::OutgoingRefsStatus::kNotTraced;
+  }
+
+  batt::Status trace_status = job->trace_new_roots(/*page_loader=*/*job, /*page_id_fn=*/
+                                                   []([[maybe_unused]] llfs::PageId page_id) {
+
+                                                   });
+  ASSERT_TRUE(trace_status.ok());
+
+  // Verify the OutgoingRefsStatus for each page.
+  //
+  const std::vector<std::unique_ptr<llfs::PageDeviceEntry>>& page_devices =
+      this->page_cache->devices_by_id();
+  for (const auto& [page_id, expected_status] : expected_outgoing_refs_status) {
+    llfs::page_device_id_int device = llfs::PageIdFactory::get_device_id(page_id);
+    u64 physical_page = page_devices[device]->arena.device().page_ids().get_physical_page(page_id);
+    llfs::page_generation_int generation =
+        page_devices[device]->arena.device().page_ids().get_generation(page_id);
+    llfs::OutgoingRefsStatus actual_status = static_cast<llfs::OutgoingRefsStatus>(
+        page_devices[device]->no_outgoing_refs_cache.get_page_bits(physical_page, generation));
+    EXPECT_EQ(actual_status, expected_status);
+  }
+
+  // Perform another call to trace_refs_recursively, this time with the PageCache itself as the
+  // PageLoader being passed in. This way, we can compare the get_count metric of PageCache to make
+  // sure we aren't doing unecessary loads in this function.
+  //
+  int initial_get_count = this->page_cache->metrics().get_count.load();
+  trace_status = job->trace_new_roots(/*page_loader=*/*(this->page_cache), /*page_id_fn=*/
+                                      []([[maybe_unused]] llfs::PageId page_id) {
+
+                                      });
+  ASSERT_TRUE(trace_status.ok());
+
+  int expected_post_trace_get_count = initial_get_count + num_pages_with_outgoing_refs;
+  EXPECT_EQ(expected_post_trace_get_count, this->page_cache->metrics().get_count.load());
+}
+
 }  // namespace

--- a/src/llfs/page_tracer.test.cpp
+++ b/src/llfs/page_tracer.test.cpp
@@ -7,16 +7,23 @@
 //+++++++++++-+-+--+----- --- -- -  -  -   -
 
 #include <llfs/page_tracer.hpp>
+
+#include <llfs/memory_log_device.hpp>
+#include <llfs/memory_page_cache.hpp>
+#include <llfs/page_graph_node.hpp>
 #include <llfs/trace_refs_recursive.hpp>
+#include <llfs/volume.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <unordered_set>
 #include <vector>
 
 namespace {
-using namespace batt::int_types;
+using namespace llfs::constants;
+using namespace llfs::int_types;
 
 class MockPageTracer : public llfs::PageTracer
 {
@@ -30,7 +37,7 @@ class MockPageTracer : public llfs::PageTracer
 //  1. Mock a PageTracer and test its integration with trace_refs_recursive by creating a DAG of
 //  PageIds.
 
-TEST(PageTracerTest, TraceRefsRecursiveTest)
+TEST(PageTracerMockTest, TraceRefsRecursiveTest)
 {
   MockPageTracer mock_tracer;
 
@@ -42,7 +49,7 @@ TEST(PageTracerTest, TraceRefsRecursiveTest)
   usize num_nodes = 100;
   std::mt19937 rng{num_nodes};
 
-  for (u16 u = 1; u <= num_nodes; ++u) {
+  for (usize u = 1; u <= num_nodes; ++u) {
     roots.insert(llfs::PageId{u});
   }
 

--- a/src/llfs/storage_context.test.cpp
+++ b/src/llfs/storage_context.test.cpp
@@ -130,11 +130,11 @@ TEST(StorageContextTest, GetPageCache)
   ASSERT_TRUE(cache.ok()) << BATT_INSPECT(cache.status());
   ASSERT_NE(*cache, nullptr);
 
-  llfs::Slice<llfs::PageCache::PageDeviceEntry* const> devices_4kb =
+  llfs::Slice<llfs::PageDeviceEntry* const> devices_4kb =
       (*cache)->devices_with_page_size(4 * kKiB);
   EXPECT_EQ(devices_4kb.size(), 1u);
 
-  llfs::Slice<llfs::PageCache::PageDeviceEntry* const> devices_2mb =
+  llfs::Slice<llfs::PageDeviceEntry* const> devices_2mb =
       (*cache)->devices_with_page_size(2 * kMiB);
   EXPECT_EQ(devices_2mb.size(), 1u);
 }

--- a/src/llfs/volume.cpp
+++ b/src/llfs/volume.cpp
@@ -168,7 +168,7 @@ u64 Volume::calculate_grant_size(const AppendableJob& appendable) const
              metadata.ids->recycler_uuid,
              metadata.ids->trimmer_uuid,
          }) {
-      for (PageCache::PageDeviceEntry* entry : cache->all_devices()) {
+      for (PageDeviceEntry* entry : cache->all_devices()) {
         BATT_CHECK_NOT_NULLPTR(entry);
         const PageArena& arena = entry->arena;
         Optional<PageAllocatorAttachmentStatus> attachment =
@@ -280,7 +280,7 @@ u64 Volume::calculate_grant_size(const AppendableJob& appendable) const
              metadata.ids->recycler_uuid,
              metadata.ids->trimmer_uuid,
          }) {
-      for (PageCache::PageDeviceEntry* entry : cache->all_devices()) {
+      for (PageDeviceEntry* entry : cache->all_devices()) {
         BATT_CHECK_NOT_NULLPTR(entry);
         BATT_REQUIRE_OK(entry->arena.allocator().notify_user_recovered(uuid));
       }

--- a/src/llfs/volume.test.cpp
+++ b/src/llfs/volume.test.cpp
@@ -1599,8 +1599,7 @@ TEST_F(VolumeSimTest, ConcurrentAppendJobs)
 
         LLFS_VLOG(1) << "checking ref counts...";
 
-        for (llfs::PageCache::PageDeviceEntry* entry :
-             sim.cache()->devices_with_page_size(1 * kKiB)) {
+        for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(1 * kKiB)) {
           BATT_CHECK_NOT_NULLPTR(entry);
           for (llfs::PageId page_id : page_ids) {
             EXPECT_EQ(entry->arena.allocator().get_ref_count(page_id).first, kExpectedRefCount);
@@ -1888,24 +1887,21 @@ void VolumeSimTest::verify_post_recovery_expectations(RecoverySimState& state,
     if (state.recovered_second_page) {
       EXPECT_FALSE(state.second_job_will_not_commit);
 
-      for (llfs::PageCache::PageDeviceEntry* entry :
-           sim.cache()->devices_with_page_size(1 * kKiB)) {
+      for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(1 * kKiB)) {
         BATT_CHECK_NOT_NULLPTR(entry);
         EXPECT_EQ(entry->arena.allocator().free_pool_size(), this->pages_per_device - 1);
         EXPECT_EQ(entry->arena.allocator().get_ref_count(state.first_page_id).first, 3);
         ASSERT_TRUE(sim.has_data_for_page_id(state.first_page_id).ok());
         EXPECT_TRUE(*sim.has_data_for_page_id(state.first_page_id));
       }
-      for (llfs::PageCache::PageDeviceEntry* entry :
-           sim.cache()->devices_with_page_size(2 * kKiB)) {
+      for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(2 * kKiB)) {
         BATT_CHECK_NOT_NULLPTR(entry);
         EXPECT_EQ(entry->arena.allocator().free_pool_size(), this->pages_per_device - 1);
         EXPECT_EQ(entry->arena.allocator().get_ref_count(state.second_root_page_id).first, 2);
         ASSERT_TRUE(sim.has_data_for_page_id(state.second_root_page_id).ok());
         EXPECT_TRUE(*sim.has_data_for_page_id(state.second_root_page_id));
       }
-      for (llfs::PageCache::PageDeviceEntry* entry :
-           sim.cache()->devices_with_page_size(4 * kKiB)) {
+      for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(4 * kKiB)) {
         BATT_CHECK_NOT_NULLPTR(entry);
         EXPECT_EQ(entry->arena.allocator().free_pool_size(), this->pages_per_device - 1);
         EXPECT_EQ(entry->arena.allocator().get_ref_count(state.third_page_id).first, 2);
@@ -1913,16 +1909,14 @@ void VolumeSimTest::verify_post_recovery_expectations(RecoverySimState& state,
         EXPECT_TRUE(*sim.has_data_for_page_id(state.third_page_id));
       }
     } else {
-      for (llfs::PageCache::PageDeviceEntry* entry :
-           sim.cache()->devices_with_page_size(1 * kKiB)) {
+      for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(1 * kKiB)) {
         BATT_CHECK_NOT_NULLPTR(entry);
         EXPECT_EQ(entry->arena.allocator().free_pool_size(), this->pages_per_device - 1);
         EXPECT_EQ(entry->arena.allocator().get_ref_count(state.first_page_id).first, 2);
         ASSERT_TRUE(sim.has_data_for_page_id(state.first_page_id).ok());
         EXPECT_TRUE(*sim.has_data_for_page_id(state.first_page_id));
       }
-      for (llfs::PageCache::PageDeviceEntry* entry :
-           sim.cache()->devices_with_page_size(2 * kKiB)) {
+      for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(2 * kKiB)) {
         BATT_CHECK_NOT_NULLPTR(entry);
         EXPECT_EQ(entry->arena.allocator().free_pool_size(), this->pages_per_device);
         if (state.second_root_page_id.is_valid()) {
@@ -1933,8 +1927,7 @@ void VolumeSimTest::verify_post_recovery_expectations(RecoverySimState& state,
           }
         }
       }
-      for (llfs::PageCache::PageDeviceEntry* entry :
-           sim.cache()->devices_with_page_size(4 * kKiB)) {
+      for (llfs::PageDeviceEntry* entry : sim.cache()->devices_with_page_size(4 * kKiB)) {
         BATT_CHECK_NOT_NULLPTR(entry);
         EXPECT_EQ(entry->arena.allocator().free_pool_size(), this->pages_per_device);
         if (state.third_page_id.is_valid()) {


### PR DESCRIPTION
This PR implements a solution to the issue described in #170. It builds upon the existing PageTracer infrastructure to cache outgoing reference information for pages.