### PR TITLE
Switch to xxHash for Bloom filters; add convenience overload for trace_refs_recursive.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -69,16 +69,18 @@ class LlfsConan(ConanFile):
 
 
     def requirements(self):
-        self.requires("batteries/0.57.2", **VISIBLE)
-        self.requires("boost/1.85.0", **VISIBLE, **OVERRIDE)
-        self.requires("cli11/2.3.2", **VISIBLE)
-        self.requires("glog/0.7.0", **VISIBLE, **OVERRIDE)
-        self.requires("gtest/1.14.0", **VISIBLE)
+        self.requires("batteries/0.58.0", **VISIBLE)
+        self.requires("boost/1.86.0", **VISIBLE, **OVERRIDE)
+        self.requires("cli11/2.4.2", **VISIBLE)
+        self.requires("glog/0.7.1", **VISIBLE, **OVERRIDE)
         self.requires("libbacktrace/cci.20210118", **VISIBLE)
-        self.requires("openssl/3.2.0", **VISIBLE)
+        self.requires("openssl/3.3.2", **VISIBLE, **OVERRIDE)
+        self.requires("xxhash/0.8.2", **VISIBLE)
 
         self.requires("zlib/1.3", **OVERRIDE)
 
+        self.test_requires("gtest/1.15.0")
+        
         if platform.system() == "Linux":
             self.requires("liburing/2.4", **VISIBLE)
             self.requires("libfuse/3.16.2", **VISIBLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,7 @@ macro(LLFS_DefineLibrary TARGET_NAME TARGET_SRCDIR)
     Boost::context
     Boost::stacktrace_backtrace
     libbacktrace::libbacktrace
+    xxHash::xxhash
     dl
     stdc++fs)
 
@@ -170,7 +171,8 @@ endmacro()
 LLFS_DefineLibrary(llfs ./llfs
   batteries::batteries
   liburing::liburing
-    OpenSSL::Crypto
+  OpenSSL::Crypto
+  xxHash::xxhash
   )
 
 #=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------

--- a/src/llfs/bloom_filter.hpp
+++ b/src/llfs/bloom_filter.hpp
@@ -22,9 +22,10 @@
 #include <batteries/static_assert.hpp>
 #include <batteries/suppress.hpp>
 
-#include <boost/functional/hash.hpp>
+#include <xxhash.h>
 
 #include <cmath>
+#include <type_traits>
 
 namespace llfs {
 
@@ -32,29 +33,55 @@ struct BloomFilterParams {
   usize bits_per_item;
 };
 
+namespace bloom_filter_impl {
+namespace {
+constexpr std::array<u64, 64> kSeeds = {
+    0xce3a9eb8b885d5afull, 0x33d9975b8a739ac6ull, 0xe65d0fff49425f03ull, 0x10bb3a132ec4fabcull,
+    0x88d476f6e7f2c53cull, 0xcb4905c588217f44ull, 0x54eb7b8b55ac05d6ull, 0xac0de731d7f3f97cull,
+    0x998963e5d908c156ull, 0x0bdf939d3b7c1cd6ull, 0x2cf7007c36b2c966ull, 0xb53c35171f25ccceull,
+    0x7d6d2ad5e3ef7ae3ull, 0xe3aaa3bf1dbffd08ull, 0xa81f70b4f8dc0f80ull, 0x1f4887ce81cdf25aull,
+    0x6433a69ba9e9d9b1ull, 0xf859167265201651ull, 0xe48c6589be0ff660ull, 0xadd5250ba0e7ac09ull,
+    0x833f55b86dee015full, 0xae3b000feb85dceaull, 0x0110cfeb4fe23291ull, 0xf3a5d699ab2ce23cull,
+    0x7c3a2b8a1c43942cull, 0x8cb3fb6783724d25ull, 0xe3619c66bf3aa139ull, 0x3fdf358be099c7d9ull,
+    0x0c38ccabc94a487full, 0x43e19e80ee4fe6edull, 0x22699c9fc26f20eeull, 0xa559cbafff2cea37ull,
+    0xfbed4777b17fb16dull, 0x7197788291858011ull, 0xa9325a240f0d996eull, 0x6782b2e3766f2f76ull,
+    0xbc3aca45c9d9dc36ull, 0x7b687762afe92061ull, 0x7b2a7cb985790bcfull, 0xf244ed1bc2b06f7dull,
+    0x29acd54ff9cb3809ull, 0xe1926523e6f67949ull, 0x98f964fbc223bb91ull, 0xaab5ee47827c5506ull,
+    0x0dab726106a4c8ddull, 0xa88bb10b8e57cdd9ull, 0xbef7ede281a687afull, 0x0e2a6b9bc5b7d6e3ull,
+    0x5b6f250b605200c8ull, 0xafe46bbd0e81722full, 0xb5d978e72ac594daull, 0x8c4362498b85fff9ull,
+    0xce8cd0d29a933471ull, 0x9c2a28aabd1e71cbull, 0x572c8c1d4ea24d86ull, 0x8fc7dff3afb5fbf7ull,
+    0xf378bc6c41606bf9ull, 0xa4c36401cf7a557full, 0x0b0a5bdd27f682afull, 0x3fbe0f66ef4777c1ull,
+    0x0ed678ccbd246356ull, 0xc2d3489afc4edcd6ull, 0xc482a884240966c6ull, 0x19b952db37267518ull,
+};
+}
+
+inline u64 get_nth_hash_for_bloom(usize hash_val, usize n)
+{
+  return XXH64(&hash_val, sizeof(hash_val), kSeeds[n & 0x3f]);
+}
+
+inline u64 get_nth_hash_for_bloom(const std::string_view& str, usize n)
+{
+  return XXH64(str.data(), str.size(), kSeeds[n & 0x3f]);
+}
+
+template <typename T,
+          typename = std::enable_if_t<!std::is_convertible_v<const T&, usize> &&
+                                      !std::is_convertible_v<const T&, std::string_view>>>
+inline u64 get_nth_hash_for_bloom(const T& item, usize n)
+{
+  return get_nth_hash_for_bloom(std::hash<T>{}(item), n);
+}
+
+}  //namespace bloom_filter_impl
+
 template <typename T, typename Fn>
 inline seq::LoopControl hash_for_bloom(const T& item, u64 count, Fn&& fn)
 {
-  static constexpr u64 kSeeds[32] = {
-      0xce3a9eb8b885d5afull, 0x33d9975b8a739ac6ull, 0xe65d0fff49425f03ull, 0x10bb3a132ec4fabcull,
-      0x88d476f6e7f2c53cull, 0xcb4905c588217f44ull, 0x54eb7b8b55ac05d6ull, 0xac0de731d7f3f97cull,
-      0x998963e5d908c156ull, 0x0bdf939d3b7c1cd6ull, 0x2cf7007c36b2c966ull, 0xb53c35171f25ccceull,
-      0x7d6d2ad5e3ef7ae3ull, 0xe3aaa3bf1dbffd08ull, 0xa81f70b4f8dc0f80ull, 0x1f4887ce81cdf25aull,
-      0x6433a69ba9e9d9b1ull, 0xf859167265201651ull, 0xe48c6589be0ff660ull, 0xadd5250ba0e7ac09ull,
-      0x833f55b86dee015full, 0xae3b000feb85dceaull, 0x0110cfeb4fe23291ull, 0xf3a5d699ab2ce23cull,
-      0x7c3a2b8a1c43942cull, 0x8cb3fb6783724d25ull, 0xe3619c66bf3aa139ull, 0x3fdf358be099c7d9ull,
-      0x0c38ccabc94a487full, 0x43e19e80ee4fe6edull, 0x22699c9fc26f20eeull, 0xa559cbafff2cea37ull};
+  using namespace bloom_filter_impl;
 
-  const auto mix_hash = [](usize a, usize b) -> usize {
-    return b + 0x9e3779b9 + (a << 6) + (a >> 2);
-  };
-
-  const u64 item_hash = std::hash<T>{}(item);
-  usize seed = item_hash;
   for (u64 i = 0; i < count; ++i) {
-    seed = mix_hash(seed, kSeeds[i % 32] + i / 32);
-    seed = mix_hash(seed, item_hash);
-    if (seq::run_loop_fn(fn, seed) == seq::LoopControl::kBreak) {
+    if (seq::run_loop_fn(fn, get_nth_hash_for_bloom(item, i)) == seq::LoopControl::kBreak) {
       return seq::LoopControl::kBreak;
     }
   }

--- a/src/llfs/bloom_filter.test.cpp
+++ b/src/llfs/bloom_filter.test.cpp
@@ -149,10 +149,19 @@ TEST(BloomFilterTest, RandomItems)
   }
 
   for (const auto& s : stats) {
-    EXPECT_LT(s.second.actual_rate() / s.second.expected_rate, 1.01)
+    const u64 word_count = s.first.first;
+    const u16 hash_count = s.first.second;
+    const double error_rate = s.second.actual_rate();
+
+    EXPECT_LT(s.second.actual_rate() / s.second.expected_rate, 1.02)
         << BATT_INSPECT(s.second.actual_rate()) << BATT_INSPECT(s.second.expected_rate);
 
-    LLFS_LOG_INFO() << BATT_INSPECT(s.second.actual_rate() / s.second.expected_rate);
+    EXPECT_GT(s.second.expected_rate / s.second.actual_rate(), 0.98)
+        << BATT_INSPECT(s.second.actual_rate()) << BATT_INSPECT(s.second.expected_rate);
+
+    LLFS_LOG_INFO() << BATT_INSPECT(s.second.actual_rate() / s.second.expected_rate)
+                    << BATT_INSPECT(word_count) << BATT_INSPECT(hash_count)
+                    << BATT_INSPECT(error_rate);
   }
 
   EXPECT_LT(false_positive_rate_total / false_positive_rate_count, 1.01);

--- a/src/llfs/bloom_filter.test.cpp
+++ b/src/llfs/bloom_filter.test.cpp
@@ -151,17 +151,21 @@ TEST(BloomFilterTest, RandomItems)
   for (const auto& s : stats) {
     const u64 word_count = s.first.first;
     const u16 hash_count = s.first.second;
-    const double error_rate = s.second.actual_rate();
 
-    EXPECT_LT(s.second.actual_rate() / s.second.expected_rate, 1.02)
-        << BATT_INSPECT(s.second.actual_rate()) << BATT_INSPECT(s.second.expected_rate);
+    // fpr == false positive rate
+    //
+    const double actual_fpr = s.second.actual_rate();
+    const double expected_fpr = s.second.expected_rate;
 
-    EXPECT_GT(s.second.expected_rate / s.second.actual_rate(), 0.98)
-        << BATT_INSPECT(s.second.actual_rate()) << BATT_INSPECT(s.second.expected_rate);
+    EXPECT_LT(actual_fpr / expected_fpr, 1.02)
+        << BATT_INSPECT(actual_fpr) << BATT_INSPECT(expected_fpr);
 
-    LLFS_LOG_INFO() << BATT_INSPECT(s.second.actual_rate() / s.second.expected_rate)
-                    << BATT_INSPECT(word_count) << BATT_INSPECT(hash_count)
-                    << BATT_INSPECT(error_rate);
+    EXPECT_GT(expected_fpr / actual_fpr, 0.98)
+        << BATT_INSPECT(actual_fpr) << BATT_INSPECT(expected_fpr);
+
+    LLFS_LOG_INFO() << BATT_INSPECT(actual_fpr / expected_fpr) << BATT_INSPECT(word_count)
+                    << BATT_INSPECT(hash_count) << BATT_INSPECT(actual_fpr)
+                    << BATT_INSPECT(expected_fpr);
   }
 
   EXPECT_LT(false_positive_rate_total / false_positive_rate_count, 1.01);

--- a/src/llfs/packed_config.hpp
+++ b/src/llfs/packed_config.hpp
@@ -13,12 +13,11 @@
 #include <llfs/crc.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/packed_array.hpp>
+#include <llfs/packed_uuid.hpp>
 #include <llfs/version.hpp>
 
 #include <batteries/static_assert.hpp>
 #include <batteries/suppress.hpp>
-
-#include <boost/uuid/uuid.hpp>
 
 #include <cstddef>
 
@@ -60,7 +59,7 @@ BATT_STATIC_ASSERT_EQ(sizeof(PackedConfigSlotBase), 4);
 struct PackedConfigSlotHeader : PackedConfigSlotBase {
   // The globally unique identifier of this object.
   //
-  boost::uuids::uuid uuid;
+  PackedUUID uuid;
 };
 
 BATT_STATIC_ASSERT_EQ(sizeof(PackedConfigSlotHeader), 20);

--- a/src/llfs/packed_page_user_slot.hpp
+++ b/src/llfs/packed_page_user_slot.hpp
@@ -10,12 +10,13 @@
 #ifndef LLFS_PACKED_PAGE_USER_SLOT_HPP
 #define LLFS_PACKED_PAGE_USER_SLOT_HPP
 
+#include <llfs/config.hpp>
+//
 #include <llfs/int_types.hpp>
 #include <llfs/packed_slot_offset.hpp>
+#include <llfs/packed_uuid.hpp>
 
 #include <batteries/static_assert.hpp>
-
-#include <boost/uuid/uuid.hpp>
 
 #include <ostream>
 
@@ -26,7 +27,7 @@ namespace llfs {
 // end-user or human, it could be another part of the system (e.g., a Tablet).
 //
 struct PackedPageUserSlot {
-  boost::uuids::uuid user_id;
+  PackedUUID user_id;
   PackedSlotOffset slot_offset;
 };
 

--- a/src/llfs/packed_uuid.cpp
+++ b/src/llfs/packed_uuid.cpp
@@ -1,0 +1,10 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#include <llfs/packed_uuid.hpp>
+//

--- a/src/llfs/packed_uuid.hpp
+++ b/src/llfs/packed_uuid.hpp
@@ -1,0 +1,79 @@
+//#=##=##=#==#=#==#===#+==#+==========+==+=+=+=+=+=++=+++=+++++=-++++=-+++++++++++
+//
+// Part of the LLFS Project, under Apache License v2.0.
+// See https://www.apache.org/licenses/LICENSE-2.0 for license information.
+// SPDX short identifier: Apache-2.0
+//
+//+++++++++++-+-+--+----- --- -- -  -  -   -
+
+#pragma once
+#ifndef LLFS_PACKED_UUID_HPP
+#define LLFS_PACKED_UUID_HPP
+
+#include <llfs/config.hpp>
+//
+
+#include <llfs/int_types.hpp>
+#include <llfs/uuid.hpp>
+
+#include <batteries/static_assert.hpp>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/version.hpp>
+
+#include <cstring>
+
+namespace llfs {
+
+struct PackedUUID {
+  std::array<u8, sizeof(boost::uuids::uuid)> bytes;
+
+  //----- --- -- -  -  -   -
+
+  PackedUUID() noexcept
+  {
+  }
+
+  /*implicit*/ PackedUUID(const boost::uuids::uuid& that) noexcept
+  {
+    *this = that;
+  }
+
+  PackedUUID& operator=(const boost::uuids::uuid& that) noexcept
+  {
+    std::memcpy(this->bytes.data(), &that, this->bytes.size());
+    return *this;
+  }
+
+#if BOOST_VERSION < 108600
+
+  operator const boost::uuids::uuid&() const noexcept
+  {
+    BATT_STATIC_ASSERT_EQ(alignof(boost::uuids::uuid), 1);
+
+    return *reinterpret_cast<const boost::uuids::uuid*>(this->bytes.data());
+  }
+
+#else
+
+  operator boost::uuids::uuid() const noexcept
+  {
+    return boost::uuids::uuid{(const u8(&)[16])this->bytes};
+  }
+
+#endif
+};
+
+BATT_STATIC_ASSERT_EQ(sizeof(PackedUUID), 16);
+BATT_STATIC_ASSERT_EQ(alignof(PackedUUID), 1);
+BATT_STATIC_ASSERT_EQ(sizeof(boost::uuids::uuid), sizeof(PackedUUID));
+
+inline std::ostream& operator<<(std::ostream& out, const PackedUUID& t)
+{
+  return out << (const boost::uuids::uuid&)t;
+}
+
+}  //namespace llfs
+
+#endif  // LLFS_PACKED_UUID_HPP

--- a/src/llfs/page_allocator.hpp
+++ b/src/llfs/page_allocator.hpp
@@ -395,7 +395,7 @@ inline StatusOr<slot_offset_type> PageAllocator::update_page_ref_counts(
   sample_count.fetch_add(1);
   prc_count.fetch_add(txn->ref_counts.size());
 
-  LLFS_LOG_INFO_EVERY_T(5.0 /*seconds*/)
+  LLFS_LOG_INFO_EVERY_T(100.0 /*seconds*/)
       << "Average pages per allocator update: "
       << ((double)prc_count.load() / (double)sample_count.load());
 

--- a/src/llfs/page_allocator_config.hpp
+++ b/src/llfs/page_allocator_config.hpp
@@ -23,12 +23,11 @@
 #include <llfs/optional.hpp>
 #include <llfs/packed_config.hpp>
 #include <llfs/packed_pointer.hpp>
+#include <llfs/packed_uuid.hpp>
 #include <llfs/page_device_config.hpp>
 #include <llfs/page_size.hpp>
 
 #include <batteries/static_assert.hpp>
-
-#include <boost/uuid/uuid.hpp>
 
 #include <iostream>
 #include <variant>
@@ -156,7 +155,7 @@ struct PackedPageAllocatorConfig : PackedConfigSlotHeader {
 
   // The PageAllocator log config.
   //
-  boost::uuids::uuid log_device_uuid;
+  PackedUUID log_device_uuid;
 
   // The page size (log2) of the page device managed by this allocator (for sanity checking).
   //

--- a/src/llfs/page_arena_config.hpp
+++ b/src/llfs/page_arena_config.hpp
@@ -10,15 +10,16 @@
 #ifndef LLFS_PAGE_ARENA_CONFIG_HPP
 #define LLFS_PAGE_ARENA_CONFIG_HPP
 
+#include <llfs/config.hpp>
+//
 #include <llfs/int_types.hpp>
 #include <llfs/log_device_runtime_options.hpp>
 #include <llfs/packed_config.hpp>
+#include <llfs/packed_uuid.hpp>
 #include <llfs/page_allocator_config.hpp>
 #include <llfs/page_arena.hpp>
 #include <llfs/page_device_config.hpp>
 #include <llfs/status.hpp>
-
-#include <boost/uuid/uuid.hpp>
 
 namespace llfs {
 
@@ -46,7 +47,7 @@ struct PageArenaConfigOptions {
 
   // The unique identifier for the arena; if None, a random UUID is generated.
   //
-  Optional<boost::uuids::uuid> uuid;
+  Optional<PackedUUID> uuid;
 
   // Config options or uuid of the PageAllocator to link to this arena.
   //
@@ -68,13 +69,13 @@ struct PackedPageArenaConfig : PackedConfigSlotHeader {
 
   // The PageAllocator config.
   //
-  boost::uuids::uuid page_allocator_uuid;
+  PackedUUID page_allocator_uuid;
 
   // byte 36 +++++++++++-+-+--+----- --- -- -  -  -   -
 
   // The PageDevice config.
   //
-  boost::uuids::uuid page_device_uuid;
+  PackedUUID page_device_uuid;
 
   // byte 52 +++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/llfs/page_cache.hpp
+++ b/src/llfs/page_cache.hpp
@@ -96,6 +96,8 @@ inline std::ostream& operator<<(std::ostream& out, const NewPageTracker& t)
 class PageCache : public PageLoader
 {
  public:
+  using PageDeviceEntry = ::llfs::PageDeviceEntry;
+
   struct PageReaderFromFile {
     PageReader page_reader;
     const char* file;

--- a/src/llfs/page_recycler_events.hpp
+++ b/src/llfs/page_recycler_events.hpp
@@ -10,8 +10,11 @@
 #ifndef LLFS_PAGE_RECYCLER_EVENTS_HPP
 #define LLFS_PAGE_RECYCLER_EVENTS_HPP
 
+#include <llfs/config.hpp>
+//
 #include <llfs/data_layout.hpp>
 #include <llfs/data_reader.hpp>
+#include <llfs/packed_uuid.hpp>
 #include <llfs/page_layout.hpp>
 #include <llfs/slot.hpp>
 
@@ -85,7 +88,7 @@ using PageRecycleEvent = PackedVariant<  //
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
 struct PackedPageRecyclerInfo {
-  boost::uuids::uuid uuid;
+  PackedUUID uuid;
   little_u32 info_refresh_rate;
   little_u32 batch_size;
   little_u32 refresh_factor;

--- a/src/llfs/volume_config.hpp
+++ b/src/llfs/volume_config.hpp
@@ -10,19 +10,20 @@
 #ifndef LLFS_VOLUME_CONFIG_HPP
 #define LLFS_VOLUME_CONFIG_HPP
 
+#include <llfs/config.hpp>
+//
 #include <llfs/constants.hpp>
 #include <llfs/data_layout.hpp>
 #include <llfs/int_types.hpp>
 #include <llfs/log_device_config2.hpp>
 #include <llfs/packed_config.hpp>
 #include <llfs/packed_pointer.hpp>
+#include <llfs/packed_uuid.hpp>
 #include <llfs/page_size.hpp>
 #include <llfs/storage_file_builder.hpp>
 #include <llfs/volume.hpp>
 #include <llfs/volume_options.hpp>
 #include <llfs/volume_runtime_options.hpp>
-
-#include <boost/uuid/uuid.hpp>
 
 #include <batteries/static_assert.hpp>
 
@@ -81,11 +82,11 @@ struct PackedVolumeConfig : PackedConfigSlotHeader {
 
   // The root log configuration.
   //
-  boost::uuids::uuid root_log_uuid;
+  PackedUUID root_log_uuid;
 
   // The recycler log configuration.
   //
-  boost::uuids::uuid recycler_log_uuid;
+  PackedUUID recycler_log_uuid;
 
   u8 pad0_[4];
 


### PR DESCRIPTION
xxHash is empirically superior to std::hash and boost::hash in terms of both speed and quality.  

https://github.com/Cyan4973/xxHash?tab=readme-ov-file#xxhash---extremely-fast-hash-algorithm

This PR adds a dependency on Conan Center's xxhash package and switches the LLFS Bloom Filter implementation to use it.  We add another 32 random seeds for hash functions, for a total of up to 64 (which should be more than enough for any reasonable scenario).

I also took the opportunity to tighten up the Bloom filter test assertions, based on the improved quality of the hashing functions.

Various other Conan requirements are also upgraded.