### PR TITLE
Fixes for PageView::get_keys parameters

### DIFF
--- a/src/llfs/api_types.hpp
+++ b/src/llfs/api_types.hpp
@@ -85,6 +85,10 @@ BATT_STRONG_TYPEDEF(usize, BufferSize);
  */
 BATT_STRONG_TYPEDEF(bool, HasOutgoingRefs);
 
+/** \brief An index into a collection of items.
+ */
+BATT_STRONG_TYPEDEF(usize, ItemOffset);
+
 }  // namespace llfs
 
 #endif  // LLFS_API_TYPES_HPP

--- a/src/llfs/page_view.cpp
+++ b/src/llfs/page_view.cpp
@@ -38,7 +38,7 @@ Status PageView::validate(PageId expected_id)
 }
 
 StatusOr<usize> PageView::get_keys([[maybe_unused]] ItemOffset lower_bound,
-                                   [[maybe_unused]] Slice<KeyView>& key_buffer_out,
+                                   [[maybe_unused]] const Slice<KeyView>& key_buffer_out,
                                    [[maybe_unused]] StableStringStore& storage) const
 {
   return StatusOr<usize>{batt::StatusCode::kUnimplemented};

--- a/src/llfs/page_view.cpp
+++ b/src/llfs/page_view.cpp
@@ -37,9 +37,8 @@ Status PageView::validate(PageId expected_id)
   return OkStatus();
 }
 
-StatusOr<usize> PageView::get_keys([[maybe_unused]] LowerBoundParam lower_bound,
-                                   [[maybe_unused]] KeyView* key_buffer_out,
-                                   [[maybe_unused]] usize key_buffer_size,
+StatusOr<usize> PageView::get_keys([[maybe_unused]] ItemOffset lower_bound,
+                                   [[maybe_unused]] Slice<KeyView>& key_buffer_out,
                                    [[maybe_unused]] StableStringStore& storage) const
 {
   return StatusOr<usize>{batt::StatusCode::kUnimplemented};

--- a/src/llfs/page_view.hpp
+++ b/src/llfs/page_view.hpp
@@ -10,6 +10,7 @@
 #ifndef LLFS_PAGE_VIEW_HPP
 #define LLFS_PAGE_VIEW_HPP
 
+#include <llfs/api_types.hpp>
 #include <llfs/key.hpp>
 #include <llfs/optional.hpp>
 #include <llfs/page_buffer.hpp>
@@ -33,7 +34,6 @@ class PageView
 {
  public:
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-  using LowerBoundParam = std::variant<KeyView, usize>;
 
   explicit PageView(std::shared_ptr<const PageBuffer>&& data) noexcept
       : data_{std::move(data)}
@@ -94,29 +94,27 @@ class PageView
    */
   virtual Optional<KeyView> max_key() const = 0;
 
-  /** \brief Retrieves at most `key_buffer_size` number of keys contained in this page.
+  /** \brief Retrieves at most the size of `key_buffer_out` number of keys contained in this page.
    *
    * \param lower_bound This parameter allows for "skipping" to an arbitrary place in the page's key
-   * set. The caller can provide either a `KeyView` value or an index into the key set, which
-   * represents the starting key from which this function will collect keys from to return.
+   * set. The caller should provide an index (offset) into the key set, which represents the
+   * starting key from which this function will collect keys from to return.
    *
    * \param key_buffer_out The output buffer that will be filled by this function with the requested
    * keys.
-   *
-   * \param key_buffer_size The size of the output buffer holding the returned keys.
    *
    * \param storage A `StableStringStore` instance that the caller can provide so that the returned
    * keys can still be a list of `KeyView` even if the keys in the page are stored in a way that
    * isn't contiguous or are compressed. Specific implementations of `PageView` will choose to use
    * this based on their key storage.
    *
-   * \return The number of keys filled into `key_buffer_out`. This value will either be
-   * `key_buffer_size` or the number of keys between `lower_bound` and the end of the key set,
-   * whichever is smaller. In the event that the `lower_bound` parameter provided does not exist in
-   * the key set (or is out of the range of the key set), this function will return 0.
+   * \return The number of keys filled into `key_buffer_out`. This value will either be the size of
+   * `key_buffer_out` or the number of keys between `lower_bound` and the end of the key set,
+   * whichever is smaller. In the event that the `lower_bound` parameter provided is out of the
+   * range of the key set, this function will return 0.
    */
-  virtual StatusOr<usize> get_keys(LowerBoundParam lower_bound, KeyView* key_buffer_out,
-                                   usize key_buffer_size, StableStringStore& storage) const;
+  virtual StatusOr<usize> get_keys(ItemOffset lower_bound, Slice<KeyView>& key_buffer_out,
+                                   StableStringStore& storage) const;
 
   // Builds a key-based approximate member query (AMQ) filter for the page, to answer the question
   // whether a given key *might* be contained by the page.

--- a/src/llfs/page_view.hpp
+++ b/src/llfs/page_view.hpp
@@ -113,7 +113,7 @@ class PageView
    * whichever is smaller. In the event that the `lower_bound` parameter provided is out of the
    * range of the key set, this function will return 0.
    */
-  virtual StatusOr<usize> get_keys(ItemOffset lower_bound, Slice<KeyView>& key_buffer_out,
+  virtual StatusOr<usize> get_keys(ItemOffset lower_bound, const Slice<KeyView>& key_buffer_out,
                                    StableStringStore& storage) const;
 
   // Builds a key-based approximate member query (AMQ) filter for the page, to answer the question


### PR DESCRIPTION
This PR provides some updates to the signature of the `get_keys` function. It changes the `lower_bound` parameter to be strictly an index value, and also changes the output buffer of keys to be a `Slice` type.