### PR TITLE
Value initialize fuse object

### DIFF
--- a/src/llfs/fuse.cpp
+++ b/src/llfs/fuse.cpp
@@ -41,19 +41,17 @@ namespace llfs {
       BATT_CHECK_NOT_NULLPTR(storage);
       storage->reset(new char[total_size]);
 
-      fuse_bufvec tmp{
-          .count = 1,
-          .idx = 0,
-          .off = 0,
-          .buf = {{
-              .size = total_size,
-              .flags = (fuse_buf_flags)0,
-              .mem = storage->get(),
-              .fd = 0,
-              .pos = 0,
-          }},
-          .mem_size = 0,
-      };
+      fuse_bufvec tmp{};
+
+      tmp.count = 1;
+      tmp.idx = 0;
+      tmp.off = 0;
+
+      tmp.buf[0].size = total_size;
+      tmp.buf[0].flags = static_cast<fuse_buf_flags>(0);
+      tmp.buf[0].mem = storage->get();
+      tmp.buf[0].fd = 0;
+      tmp.buf[0].pos = 0;
 
       const isize n_copied = fuse_buf_copy(&tmp, &bufv, /*flags=*/(fuse_buf_copy_flags)0);
       if (n_copied < 0) {

--- a/src/llfs/fuse.cpp
+++ b/src/llfs/fuse.cpp
@@ -52,6 +52,7 @@ namespace llfs {
               .fd = 0,
               .pos = 0,
           }},
+          .mem_size = 0,
       };
 
       const isize n_copied = fuse_buf_copy(&tmp, &bufv, /*flags=*/(fuse_buf_copy_flags)0);


### PR DESCRIPTION
Newer versions of fuse have added additional member variables to fuse_bufvec. List initializing fails with a compilation error due to this. To support both older and newer version of fuse, value initialize instead.